### PR TITLE
Transactional v1

### DIFF
--- a/createsend/__init__.py
+++ b/createsend/__init__.py
@@ -1,4 +1,4 @@
-from createsend import __version__
+﻿from createsend import __version__
 from createsend import *
 from client import Client
 from template import Template
@@ -8,4 +8,5 @@ from subscriber import Subscriber
 from campaign import Campaign
 from person import Person
 from administrator import Administrator
+from transactional import Transactional
 import utils

--- a/createsend/transactional.py
+++ b/createsend/transactional.py
@@ -16,7 +16,7 @@ class Transactional(CreateSendBase):
     """Gets the smart email list."""
     if client_id is None:
       response = self._get("/transactional/smartEmail?status=%s" % status)
-    else: 
+    else:
       response = self._get("/transactional/smartEmail?status=%s&clientID=%s" % (status, client_id))
     return json_to_py(response)
 
@@ -27,8 +27,8 @@ class Transactional(CreateSendBase):
 
   def smart_email_send(self, smart_email_id, to, cc=None, bcc=None, attachments=None, data=None, add_recipients_to_list=None):
      """Sends the smart email."""
-     body = { 
-      "To": to, 
+     body = {
+      "To": to,
       "CC": cc,
       "BCC": bcc,
       "Attachments": attachments,
@@ -37,12 +37,12 @@ class Transactional(CreateSendBase):
      response = self._post("/transactional/smartEmail/%s/send" % smart_email_id, json.dumps(body))
      return json_to_py(response)
 
-  def basic_email_send(self, subject, from_address, to, client_id=None, cc=None, bcc=None, html=None, text=None, attachments=None, track_opens=True, track_clicks=True, inline_css=True, basic_group=None, add_recipients_to_list=None):
+  def classic_email_send(self, subject, from_address, to, client_id=None, cc=None, bcc=None, html=None, text=None, attachments=None, track_opens=True, track_clicks=True, inline_css=True, group=None, add_recipients_to_list=None):
      """Sends the basic email."""
-     body = { 
-      "Subject": subject, 
+     body = {
+      "Subject": subject,
       "From": from_address,
-      "To": to, 
+      "To": to,
       "CC": cc,
       "BCC": bcc,
       "HTML": html,
@@ -51,20 +51,20 @@ class Transactional(CreateSendBase):
       "TrackOpens": track_opens,
       "TrackClicks": track_clicks,
       "InlineCSS": inline_css,
-      "BasicGroup": basic_group,
+      "Group": group,
       "AddRecipientsToList": add_recipients_to_list }
      if client_id is None:
-       response = self._post("/transactional/basicEmail/send", json.dumps(body))
+       response = self._post("/transactional/classicEmail/send", json.dumps(body))
      else:
-       response = self._post("/transactional/basicEmail/send?clientID=%s" % client_id, json.dumps(body))     
+       response = self._post("/transactional/classicEmail/send?clientID=%s" % client_id, json.dumps(body))
      return json_to_py(response)
 
-  def basic_email_list(self, client_id=None):
-    """Gets the list of basic email groups."""
+  def classic_email_groups(self, client_id=None):
+    """Gets the list of classic email groups."""
     if client_id is None:
-      response = self._get("/transactional/basicEmail/groups")
-    else: 
-      response = self._get("/transactional/basicEmail/groups?clientID=%s" % client_id)
+      response = self._get("/transactional/classicEmail/groups")
+    else:
+      response = self._get("/transactional/classicEmail/groups?clientID=%s" % client_id)
     return json_to_py(response)
 
   def statistics(self, params={}):

--- a/createsend/transactional.py
+++ b/createsend/transactional.py
@@ -1,0 +1,88 @@
+﻿try:
+  import json
+except ImportError:
+  import simplejson as json
+from createsend import CreateSendBase
+from utils import json_to_py
+
+class Transactional(CreateSendBase):
+  """Represents transactional functionality."""
+
+  def __init__(self, auth=None, client_id=None):
+    self.client_id = client_id
+    super(Transactional, self).__init__(auth)
+
+  def smart_email_list(self, status="all", client_id=None):
+    """Gets the smart email list."""
+    if client_id is None:
+      response = self._get("/transactional/smartEmail?status=%s" % status)
+    else: 
+      response = self._get("/transactional/smartEmail?status=%s&clientID=%s" % (status, client_id))
+    return json_to_py(response)
+
+  def smart_email_details(self, smart_email_id):
+    """Gets the smart email details."""
+    response = self._get("/transactional/smartEmail/%s" % smart_email_id)
+    return json_to_py(response)
+
+  def smart_email_send(self, smart_email_id, to, cc=None, bcc=None, attachments=None, data=None, add_recipients_to_list=None):
+     """Sends the smart email."""
+     body = { 
+      "To": to, 
+      "CC": cc,
+      "BCC": bcc,
+      "Attachments": attachments,
+      "Data": data,
+      "AddRecipientsToList": add_recipients_to_list }
+     response = self._post("/transactional/smartEmail/%s/send" % smart_email_id, json.dumps(body))
+     return json_to_py(response)
+
+  def basic_email_send(self, subject, from_address, to, client_id=None, cc=None, bcc=None, html=None, text=None, attachments=None, track_opens=True, track_clicks=True, inline_css=True, basic_group=None, add_recipients_to_list=None):
+     """Sends the basic email."""
+     body = { 
+      "Subject": subject, 
+      "From": from_address,
+      "To": to, 
+      "CC": cc,
+      "BCC": bcc,
+      "HTML": html,
+      "Text": text,
+      "Attachments": attachments,
+      "TrackOpens": track_opens,
+      "TrackClicks": track_clicks,
+      "InlineCSS": inline_css,
+      "BasicGroup": basic_group,
+      "AddRecipientsToList": add_recipients_to_list }
+     if client_id is None:
+       response = self._post("/transactional/basicEmail/send", json.dumps(body))
+     else:
+       response = self._post("/transactional/basicEmail/send?clientID=%s" % client_id, json.dumps(body))     
+     return json_to_py(response)
+
+  def basic_email_list(self, client_id=None):
+    """Gets the list of basic email groups."""
+    if client_id is None:
+      response = self._get("/transactional/basicEmail/groups")
+    else: 
+      response = self._get("/transactional/basicEmail/groups?clientID=%s" % client_id)
+    return json_to_py(response)
+
+  def statistics(self, params={}):
+    """Gets the statistics according to the parameters."""
+    response = self._get("/transactional/statistics", params)
+    return json_to_py(response)
+
+  def message_timeline(self, params={}):
+    """Gets the messages timeline according to the parameters."""
+    response = self._get("/transactional/messages", params)
+    return json_to_py(response)
+
+  def message_details(self, message_id, statistics=False):
+    """Gets the details of this message."""
+    response = self._get("/transactional/messages/%s?statistics=%s" % (message_id, statistics))
+    return json_to_py(response)
+
+  def message_resend(self, message_id):
+    """Resend the message."""
+    response = self._post("/transactional/messages/%s/resend" % message_id)
+    return json_to_py(response)

--- a/createsend/transactional.py
+++ b/createsend/transactional.py
@@ -38,7 +38,7 @@ class Transactional(CreateSendBase):
      return json_to_py(response)
 
   def classic_email_send(self, subject, from_address, to, client_id=None, cc=None, bcc=None, html=None, text=None, attachments=None, track_opens=True, track_clicks=True, inline_css=True, group=None, add_recipients_to_list=None):
-     """Sends the basic email."""
+     """Sends a classic email."""
      body = {
       "Subject": subject,
       "From": from_address,

--- a/test/fixtures/tx_classicemail_groups.json
+++ b/test/fixtures/tx_classicemail_groups.json
@@ -1,0 +1,14 @@
+[
+    {
+        "Group": "Password Reset",
+        "CreatedAt": "2015-03-28T09:41:36+11:00"
+    },
+    {
+        "Group": "Credit card expired",
+        "CreatedAt": "2015-05-04T22:24:12+10:00"
+    },
+    {
+        "Group": "Order shipped",
+        "CreatedAt": "2015-03-29T11:11:52+11:00"
+    }
+]

--- a/test/fixtures/tx_message_details.json
+++ b/test/fixtures/tx_message_details.json
@@ -1,0 +1,36 @@
+{
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Delivered",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "SmartEmailID": "c0da9c4c-e7e4-11e4-a74d-6c4008bc7468",
+    "CanBeResent": true,
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "Message": {
+        "From": "Team Webapp <team@webapp123.com",
+        "Subject": "Thanks for signing up to web app 123",
+        "To": [
+          "Joe Smith <joesmith@example.com>",
+          "jamesmith@example.com"
+        ],
+        "CC": [
+          "Joe Smith <joesmith@example.com>"
+        ],
+        "BCC": "joesmith@example.com",
+        "Attachments": [
+            {
+                "Name": "Invoice.pdf",
+                "Type": "application/pdf"
+            }
+        ],
+        "Body": {
+            "Html": "...",
+            "Text": "..."
+        },
+        "Data": {
+            "new_password_url": "https://www.mywebapp.com/newpassword?uid=jguf45hf74hbf74gf"
+        }
+    },
+    "TotalOpens": 1,
+    "TotalClicks": 1
+}
+

--- a/test/fixtures/tx_message_details_with_statistics.json
+++ b/test/fixtures/tx_message_details_with_statistics.json
@@ -1,0 +1,72 @@
+{
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Delivered",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "SmartEmailID": "c0da9c4c-e7e4-11e4-a74d-6c4008bc7468",
+    "CanBeResent": true,
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "Message": {
+        "From": "Team Webapp <team@webapp123.com",
+        "Subject": "Thanks for signing up to web app 123",
+        "To": [
+          "Joe Smith <joesmith@example.com>",
+          "jamesmith@example.com"
+        ],
+        "CC": [
+          "Joe Smith <joesmith@example.com>"
+        ],
+        "BCC": "joesmith@example.com",
+        "Attachments": [
+            {
+                "Name": "Invoice.pdf",
+                "Type": "application/pdf"
+            }
+        ],
+        "Body": {
+            "Html": "...",
+            "Text": "..."
+        },
+        "Data": {
+            "new_password_url": "https://www.mywebapp.com/newpassword?uid=jguf45hf74hbf74gf"
+        }
+    },
+    "TotalOpens": 1,
+    "TotalClicks": 1,
+    "Opens": [
+        {
+            "EmailAddress": "jamesmith@example.com",
+            "Date": "2009-05-18 16:45:00",
+            "IPAddress": "192.168.0.1",
+            "Geolocation": {
+                "Latitude": -33.8683,
+                "Longitude": 151.2086,
+                "City": "Sydney",
+                "Region": "New South Wales",
+                "CountryCode": "AU",
+                "CountryName": "Australia"
+            },
+            "MailClient": {
+                "Name": "Apple Mail",
+                "OS": "OS X",
+                "Device": "Desktop"
+            }
+        }
+    ],
+    "Clicks": [
+        {
+            "EmailAddress": "jamesmith@example.com",
+            "Date": "2009-05-18 16:45:00",
+            "IPAddress": "192.168.0.1",
+            "URL": "http://www.myexammple.com/index.html",
+            "Geolocation": {
+              "Latitude": -33.8683,
+              "Longitude": 151.2086,
+              "City": "Sydney",
+              "Region": "New South Wales",
+              "CountryCode": "AU",
+              "CountryName": "Australia"
+            }
+        }
+    ]
+}
+

--- a/test/fixtures/tx_messages.json
+++ b/test/fixtures/tx_messages.json
@@ -1,0 +1,38 @@
+[
+  {
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Delivered",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "From": "Team <team@company.com>",
+    "Subject": "Ungrouped message",
+    "TotalOpens": 2,
+    "TotalClicks": 4,
+    "CanBeResent": true
+  },
+  {
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Delivered",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "From": "Team <team@company.com>",
+    "Subject": "Your password has been reset",
+    "TotalOpens": 2,
+    "TotalClicks": 4,
+    "CanBeResent": true,
+    "Group": "Password Reset"
+  },
+  {
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Bounced",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "From": "Team <team@company.com>",
+    "Subject": "Your credit card has expired",
+    "TotalOpens": 2,
+    "TotalClicks": 4,
+    "CanBeResent": true,
+    "SmartEmailID": "21dab350-f484-11e4-ad38-6c4008bc7468"
+  }
+]
+

--- a/test/fixtures/tx_messages_classic.json
+++ b/test/fixtures/tx_messages_classic.json
@@ -1,0 +1,15 @@
+[
+  {
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Delivered",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "From": "Team <team@company.com>",
+    "Subject": "Your password has been reset",
+    "TotalOpens": 2,
+    "TotalClicks": 4,
+    "CanBeResent": true,
+    "Group": "Password Reset"
+  }
+]
+

--- a/test/fixtures/tx_messages_smart.json
+++ b/test/fixtures/tx_messages_smart.json
@@ -1,0 +1,15 @@
+[
+  {
+    "MessageID": "ddc697c7-0788-4df3-a71a-a7cb935f00bd",
+    "Status": "Delivered",
+    "SentAt": "2014-01-15T16:09:19-05:00",
+    "Recipient": "Joe Smith <joesmith@example.com>",
+    "From": "Team <team@company.com>",
+    "Subject": "Your credit card has expired",
+    "TotalOpens": 2,
+    "TotalClicks": 4,
+    "CanBeResent": true,
+    "SmartEmailID": "21dab350-f484-11e4-ad38-6c4008bc7468"
+  }
+]
+

--- a/test/fixtures/tx_send_multiple.json
+++ b/test/fixtures/tx_send_multiple.json
@@ -1,0 +1,12 @@
+[
+    {
+        "MessageID": "0cfe150d-d507-11e4-84a7-c31e5b59881d",
+        "Recipient": "\"Bob Sacamano\" <bob@example.com>",
+        "Status": "Received"
+    },
+    {
+        "MessageID": "0cfe150d-d507-11e4-b579-a64eb0d9c74d",
+        "Recipient": "\"Newman\" <newman@example.com>",
+        "Status": "Received"
+    }
+]

--- a/test/fixtures/tx_send_single.json
+++ b/test/fixtures/tx_send_single.json
@@ -1,0 +1,7 @@
+[
+    {
+        "MessageID": "0cfe150d-d507-11e4-84a7-c31e5b59881d",
+        "Recipient": "\"Bob Sacamano\" <bob@example.com>",
+        "Status": "Received"
+    }
+]

--- a/test/fixtures/tx_smartemail_details.json
+++ b/test/fixtures/tx_smartemail_details.json
@@ -1,0 +1,23 @@
+{
+    "SmartEmailID": "bb4a6ebb-663d-42a0-bdbe-60512cf30a01",
+    "Name": "Reset Password",
+    "CreatedAt": "2015-03-31T16:06:35+11:00",
+    "Status": "active",
+    "Properties": {
+        "From": "\"Team\" <team@example.com>",
+        "ReplyTo": "joe@example.com",
+        "Subject": "[username], your password has been reset!",
+        "Content": {
+            "HTML": "Content managed in Email Builder",
+            "Text": "Content managed in Email Builder",
+            "EmailVariables": [
+                "username",
+                "reset_token"
+            ],
+            "InlineCss": true
+        },
+        "TextPreviewUrl": "https://philoye.devcreatesend.com/t/r-9A7A28EE76054977/T",
+        "HtmlPreviewUrl": "https://philoye.devcreatesend.com/t/r-9A7A28EE76054977/"
+    },
+    "AddRecipientsToList": true
+}

--- a/test/fixtures/tx_smartemails.json
+++ b/test/fixtures/tx_smartemails.json
@@ -1,0 +1,15 @@
+[
+    {
+        "ID": "1e654df2-f484-11e4-970c-6c4008bc7468",
+        "Name": "Welcome email",
+        "CreatedAt": "2015-05-15T16:09:19-05:00",
+        "Status": "Active"
+    },
+    {
+        "ID": "21dab350-f484-11e4-ad38-6c4008bc7468",
+        "Name": "Order shipped",
+        "CreatedAt": "2015-05-15T13:29:49-05:00",
+        "Status": "Draft"
+    }
+]
+

--- a/test/fixtures/tx_statistics_classic.json
+++ b/test/fixtures/tx_statistics_classic.json
@@ -1,0 +1,14 @@
+{
+    "Query": {
+      "Group": "Password Reset",
+      "From": "2014-02-03",
+      "To": "2015-02-02",
+      "TimeZone": "(GMT+10:00) Canberra, Melbourne, Sydney"
+    },
+    "Sent": 1000,
+    "Bounces": 8,
+    "Delivered": 992,
+    "Opened": 300,
+    "Clicked": 50
+}
+

--- a/test/fixtures/tx_statistics_smart.json
+++ b/test/fixtures/tx_statistics_smart.json
@@ -1,0 +1,14 @@
+{
+    "Query": {
+      "SmartEmailID": "bb4a6ebb-663d-42a0-bdbe-60512cf30a01",
+      "From": "2014-02-03",
+      "To": "2015-02-02",
+      "TimeZone": "UTC"
+    },
+    "Sent": 1000,
+    "Bounces": 8,
+    "Delivered": 992,
+    "Opened": 300,
+    "Clicked": 50
+}
+

--- a/test/test_transactional.py
+++ b/test/test_transactional.py
@@ -1,0 +1,120 @@
+import unittest
+import urllib
+
+from createsend import *
+
+class TransactionalTestCase(object):
+
+    def test_smart_email_list(self):
+        status = "all"
+        self.tx.stub_request("transactional/smartEmail?status=%s" % status, "tx_smartemails.json")
+        list = self.tx.smart_email_list(status)
+        self.assertEqual(list[0].Name, "Welcome email")
+
+    def test_active_smart_email_list(self):
+        self.tx.stub_request("transactional/smartEmail?status=active", "tx_smartemails.json")
+        list = self.tx.smart_email_list(status="active")
+        self.assertEqual(list[0].Status, "Active")
+
+    def test_smart_email_list_with_client(self):
+        self.tx.stub_request("transactional/smartEmail?status=all&clientID=%s" % self.client_id, "tx_smartemails.json")
+        list = self.tx.smart_email_list(client_id=self.client_id)
+        self.assertEqual(list[0].Name, "Welcome email")
+
+    def test_smart_email_details(self):
+        self.tx.stub_request("transactional/smartEmail/%s" % self.smart_email_id, "tx_smartemail_details.json")
+        email = self.tx.smart_email_details(self.smart_email_id)
+        self.assertEqual(email.Name, "Reset Password")
+
+    def test_smart_email_send_single(self):
+        self.tx.stub_request("transactional/smartEmail/%s/send" % self.smart_email_id, "tx_send_single.json")
+        send = self.tx.smart_email_send(self.smart_email_id,  "\"Bob Sacamano\" <bob@example.com>")
+        self.assertEqual(send[0].Status, "Received")
+
+    def test_smart_email_send_multiple(self):
+        self.tx.stub_request("transactional/smartEmail/%s/send" % self.smart_email_id, "tx_send_multiple.json")
+        send = self.tx.smart_email_send(self.smart_email_id,  ["\"Bob Sacamano\" <bob@example.com>", "\"Newman\" <newman@example.com>"])
+        self.assertEqual(send[1].Recipient, "\"Newman\" <newman@example.com>")
+
+    def test_classic_email_send(self):
+        self.tx.stub_request("transactional/classicEmail/send", "tx_send_single.json")
+        send = self.tx.classic_email_send("This is the subject", "from@example.com", "\"Bob Sacamano\" <bob@example.com>")
+        self.assertEqual(send[0].Recipient, "\"Bob Sacamano\" <bob@example.com>")
+
+    def test_classic_email_groups(self):
+        self.tx.stub_request("transactional/classicEmail/groups", "tx_classicemail_groups.json")
+        groups = self.tx.classic_email_groups()
+        self.assertEqual(groups[0].Group, "Password Reset")
+
+    def test_classic_email_groups_with_client(self):
+        self.tx.stub_request("transactional/classicEmail/groups?clientID=%s" % self.client_id, "tx_classicemail_groups.json")
+        groups = self.tx.classic_email_groups(client_id=self.client_id)
+        self.assertEqual(groups[0].Group, "Password Reset")
+
+    def test_statistics(self):
+        self.tx.stub_request("transactional/statistics", "tx_statistics_classic.json")
+        stats = self.tx.statistics()
+        self.assertEqual(stats.Query.Group, "Password Reset")
+
+    def test_statistics_with_options(self):
+        start = "2014-02-03"
+        end = "2015-02-02"
+        self.tx.stub_request('transactional/statistics?to=%s&from=%s&clientID=%s' % (end, start, self.client_id), "tx_statistics_classic.json")
+        stats = self.tx.statistics({'clientID': self.client_id, 'from': start, 'to': end})
+        self.assertEqual(stats.Query.Group, "Password Reset")
+
+    def test_timeline(self):
+        self.tx.stub_request("transactional/messages", "tx_messages.json")
+        timeline = self.tx.message_timeline()
+        self.assertEqual(len(timeline), 3)
+        self.assertEqual(timeline[0].Status, "Delivered")
+
+    def test_timeline_classic_with_options(self):
+        self.tx.stub_request('transactional/messages?status=%s&group=%s' % ("all", "Password+Reset"), "tx_messages_classic.json")
+        timeline = self.tx.message_timeline({'status':'all','group':'Password Reset'})
+        self.assertEqual(timeline[0].Group, "Password Reset")
+
+    def test_timeline_smart_with_options(self):
+        self.tx.stub_request('transactional/messages?status=%s&smartEmailID=%s' % ("all", self.smart_email_id), "tx_messages_smart.json")
+        timeline = self.tx.message_timeline({'status':'all','smartEmailID':self.smart_email_id})
+        self.assertEqual(timeline[0].SmartEmailID, self.smart_email_id)
+
+    def test_message_details(self):
+        self.tx.stub_request('transactional/messages/%s?statistics=False' % (self.message_id), "tx_message_details.json")
+        msg = self.tx.message_details(self.message_id, statistics=False)
+        self.assertEqual(msg.MessageID, self.message_id)
+
+    def test_message_details_with_stats(self):
+        self.tx.stub_request('transactional/messages/%s?statistics=True' % (self.message_id), "tx_message_details_with_statistics.json")
+        msg = self.tx.message_details(self.message_id, statistics=True)
+        self.assertEqual(len(msg.Opens), 1)
+        self.assertEqual(len(msg.Clicks), 1)
+
+    def test_message_resend(self):
+        self.tx.stub_request('transactional/messages/%s/resend' % (self.message_id), "tx_send_single.json")
+        send = self.tx.message_resend(self.message_id)
+        self.assertEqual(send[0].Status, "Received")
+
+
+class OAuthTransactionalTestCase(unittest.TestCase, TransactionalTestCase):
+  """Test when using OAuth to authenticate"""
+  def setUp(self):
+    self.client_id      = '87y8d7qyw8d7yq8w7ydwqwd'
+    self.smart_email_id = '21dab350-f484-11e4-ad38-6c4008bc7468'
+    self.message_id     = 'ddc697c7-0788-4df3-a71a-a7cb935f00bd'
+    self.before_id      = 'e2e270e6-fbce-11e4-97fc-a7cf717ca157'
+    self.after_id       = 'e96fc6ca-fbce-11e4-949f-c3ccd6a68863'
+    self.tx = Transactional(
+      {"access_token": "ASP95S4aR+9KsgfHB0dapTYxNA==", "refresh_token": "5S4aASP9R+9KsgfHB0dapTYxNA=="}, "admin@example.com")
+
+class ApiKeyTransactionalTestCase(unittest.TestCase, TransactionalTestCase):
+  """Test when using an API key to authenticate"""
+  def setUp(self):
+    self.client_id      = '87y8d7qyw8d7yq8w7ydwqwd'
+    self.smart_email_id = '21dab350-f484-11e4-ad38-6c4008bc7468'
+    self.message_id     = 'ddc697c7-0788-4df3-a71a-a7cb935f00bd'
+    self.before_id      = 'e2e270e6-fbce-11e4-97fc-a7cf717ca157'
+    self.after_id       = 'e96fc6ca-fbce-11e4-949f-c3ccd6a68863'
+    self.tx = Transactional(
+      {'api_key': '123123123123123123123'}, "admin@example.com")
+


### PR DESCRIPTION
Campaign Monitor is releasing it's new Transactional for Marketers capability in the near future. As a part of that, there is a new API for Transactional. This pull request includes the addition of a wrapper to call those API methods for Python.

This PR supercedes https://github.com/campaignmonitor/createsend-python/pull/22

To be merged in when Transactional for Marketers is released.