### PR TITLE
Fix installation error when 'six' is missing

### DIFF
--- a/createsend/__init__.py
+++ b/createsend/__init__.py
@@ -8,4 +8,5 @@ from .campaign import Campaign
 from .person import Person
 from .administrator import Administrator
 from .transactional import Transactional
+from .version import __version__
 from . import utils

--- a/createsend/createsend.py
+++ b/createsend/createsend.py
@@ -11,8 +11,6 @@ except ImportError:
   import simplejson as json
 from .utils import VerifiedHTTPSConnection, json_to_py, get_faker
 
-__version_info__ = ('4', '1', '1')
-__version__ = '.'.join(__version_info__)
 
 class CreateSendError(Exception):
   """Represents a CreateSend API error and contains specific data about the error."""

--- a/createsend/createsend.py
+++ b/createsend/createsend.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
   import simplejson as json
 from .utils import VerifiedHTTPSConnection, json_to_py, get_faker
+from .version import __version__
 
 
 class CreateSendError(Exception):

--- a/createsend/version.py
+++ b/createsend/version.py
@@ -1,0 +1,2 @@
+__version_info__ = ('4', '1', '1')
+__version__ = '.'.join(__version_info__)

--- a/createsend/version.py
+++ b/createsend/version.py
@@ -1,2 +1,2 @@
-__version_info__ = ('4', '1', '1')
+__version_info__ = ('4', '2', '0')
 __version__ = '.'.join(__version_info__)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 import os
 from distutils.core import setup
 
-from createsend.createsend import __version__
+execfile('createsend/version.py')
 
 setup(name = "createsend",
       version = __version__,
@@ -13,4 +13,6 @@ setup(name = "createsend",
       license = "MIT",
       keywords = "createsend campaign monitor email",
       packages = ['createsend'],
-      package_data = {'createsend': ['cacert.pem']})
+      package_data = {'createsend': ['cacert.pem']},
+      install_requires = ['six'],
+      )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ import sys
 import os
 from distutils.core import setup
 
-exec(open('createsend/version.py').read())
+with open('createsend/version.py') as fp:
+    exec(fp.read())
 
 setup(name = "createsend",
       version = __version__,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 import os
 from distutils.core import setup
 
-execfile('createsend/version.py')
+exec(open('createsend/version.py').read())
 
 setup(name = "createsend",
       version = __version__,


### PR DESCRIPTION
Running `setup.py` in the current version fails if `six` is not already installed, because `six` is imported in `createsend.createsend`.
