### PR TITLE
Use CGI SERVER_NAME in UA string (fixes #28)

### DIFF
--- a/createsend/createsend.py
+++ b/createsend/createsend.py
@@ -216,9 +216,10 @@ class CreateSend(CreateSendBase):
   base_uri = "https://api.createsend.com/api/v3.1"
   oauth_uri = "https://api.createsend.com/oauth"
   oauth_token_uri = "%s/token" % oauth_uri
+  platform = os.getenv('SERVER_SOFTWARE') or platform.platform()
   default_user_agent = 'createsend-python-%s-%d.%d.%d-%s' % (
     __version__, sys.version_info[0], sys.version_info[1],
-    sys.version_info[2], platform.platform())
+    sys.version_info[2], platform)
   # You can use `CreateSend.user_agent = "my user agent"` to override the
   # default user agent string (CreateSend.default_user_agent) used when
   # making API calls.


### PR DESCRIPTION
Get platform name for user agent string from the standard CGI server env var `SERVER_SOFTWARE` if present.

This prevents the library from raising an exception on Google App Engine.

Closes #28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/campaignmonitor/createsend-python/32)
<!-- Reviewable:end -->
