### PR TITLE
Support Unicode when decoding json responses from createsend API

### DIFF
--- a/createsend/utils.py
+++ b/createsend/utils.py
@@ -107,7 +107,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
       raise
 
 def json_to_py(j):
-  o = json.loads(j.decode())
+  o = json.loads(j.decode('utf-8'))
   if isinstance(o, dict):
   	return dict_to_object(o)
   else:

--- a/test/fixtures/custom_fields_utf8.json
+++ b/test/fixtures/custom_fields_utf8.json
@@ -1,0 +1,16 @@
+[
+  {
+    "FieldName": "salary_range",
+    "Key": "[]",
+    "DataType": "MultiSelectOne",
+    "FieldOptions": ["£0-20k", "£20-30k", "£30k+"],
+    "VisibleInPreferenceCenter": true
+  },
+  {
+    "FieldName": "age",
+    "Key": "[age]",
+    "DataType": "Number",
+    "FieldOptions": [],
+    "VisibleInPreferenceCenter": true
+  }
+]

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from six.moves.urllib.parse import quote
 import unittest
 
@@ -88,6 +90,14 @@ class ListTestCase(object):
     self.assertEquals(cfs[0].DataType, "Text")
     self.assertEquals(cfs[0].FieldOptions, [])
     self.assertEquals(cfs[0].VisibleInPreferenceCenter, True)
+  
+  def test_custom_fields_utf8(self):
+    self.list.stub_request("lists/%s/customfields.json" % self.list.list_id, "custom_fields_utf8.json")
+    cfs = self.list.custom_fields()
+    self.assertEquals(len(cfs), 2)
+    self.assertEquals(cfs[0].FieldName, "salary_range")
+    self.assertEquals(cfs[0].FieldOptions, [u"£0-20k", u"£20-30k", u"£30k+"])
+
 
   def test_segments(self):
     self.list.stub_request("lists/%s/segments.json" % self.list.list_id, "segments.json")


### PR DESCRIPTION
This fixes #37 