### PR TITLE
Add timeout to CreateSendBase, passed to HTTPSConnection.

### DIFF
--- a/lib/createsend/createsend.py
+++ b/lib/createsend/createsend.py
@@ -5,6 +5,7 @@ import platform
 import base64
 import gzip
 import os
+import socket
 import json
 from six import BytesIO
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
@@ -60,6 +61,7 @@ class ExpiredOAuthToken(Unauthorized):
 
 class CreateSendBase(object):
     auth_details = None
+    timeout = socket._GLOBAL_DEFAULT_TIMEOUT  # passed to VerifiedHTTPSConnection
 
     def __init__(self, auth):
         self.fake_web = False
@@ -201,7 +203,7 @@ class CreateSendBase(object):
                 self.faker and self.faker.status) else 200
             return self.handle_response(status, data)
 
-        c = VerifiedHTTPSConnection(parsed_base_uri.netloc)
+        c = VerifiedHTTPSConnection(parsed_base_uri.netloc, timeout=self.timeout)
         c.request(method, self.build_url(
             parsed_base_uri, path, params), body, headers)
         response = c.getresponse()


### PR DESCRIPTION
This is a rework of https://github.com/campaignmonitor/createsend-python/pull/26 which was badly out of date.

The current behaviour is that the default timeout is used when API requests are made, matching whatever `socket.getdefaulttimeout()` returns.  This patch allows setting a timeout that only affects the createsend API, so that `socket.setdefaulttimeout` does not have to be called.

To set a timeout for createsend (without changing the global socket default timeout), create an instance and assign a new timeout, like this:

```python
import createsend

mailing_list = createsend.List(list_id=<list id>, auth=<credentials>, ...)
mailing_list.timeout = 10  # timeout after 10 seconds
subscribers = [subscriber for subscriber in mailing_list.active().Results]
```

If the timeout attribute is not set, then the previous behaviour is maintained.