### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # createsend
 
-A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 2.6, 2.7, 3.3, 3.4, or 3.5.
+A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 2.7, 3.3, 3.4, or 3.5.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         "Programming Language :: Python :: 3",
 
         # Specifically, we support the following releases.
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.0",
         "Programming Language :: Python :: 3.1",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pip is broken on py32
-envlist = py26, py27, py30, py31, py33, py34, py35, py36, py37
+envlist = py27, py30, py31, py33, py34, py35, py36, py37
 
 [testenv]
 install_command=pip install {packages}


### PR DESCRIPTION
Python 2.6 hasn't been supported for a long time.  [There was an issue](https://github.com/campaignmonitor/createsend-python/pull/58#issuecomment-379955442) where coveralls failed to run causing the build to fail prompting this PR.