### PR TITLE
Minor changes to consent_to_track & README.md

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,14 @@
 # createsend-python history
 
+## v6.0.1 - 24 July, 2018
+
+* Changes ``consent_to_track`` parameter to also accept a nullable boolean
+* Updates README.md with information about breaking changes in v6.0.x
 
 ## v6.0.0 - 21 May, 2018
 
 * Upgrades to Createsend API v3.2 which includes new breaking changes
-* Breaking: 'Consent to track' field is now mandatory for sending smart and classic transactionl emails
+* Breaking: 'Consent to track' field is now mandatory for sending smart and classic transactional emails
 * Breaking: 'Consent to track' field is now mandatory when adding or updating subscribers
 * Optional 'Include tracking preference' field when retrieving lists of subscribers
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A Python library which implements the complete functionality of the [Campaign Mo
 pip install createsend
 ```
 
+## Upgrading to 6.0.0 from an earlier version
+
+Please note there is a breaking change in the API; the ``consent_to_track`` parameter is now mandatory for sending smart and classic transactional emails, and adding or updating subscribers.  You can read more about this [in the Campaign Monitor docs](https://help.campaignmonitor.com/consent-to-track).
+
 ## Authenticating
 
 The Campaign Monitor API supports authentication using either OAuth or an API key.

--- a/lib/createsend/subscriber.py
+++ b/lib/createsend/subscriber.py
@@ -34,7 +34,6 @@ class Subscriber(CreateSendBase):
             "Resubscribe": resubscribe,
             "ConsentToTrack": consent_to_track,
             "RestartSubscriptionBasedAutoresponders": restart_subscription_based_autoresponders}
-        print(body)
         response = self._post("/subscribers/%s.json" %
                               list_id, json.dumps(body))
         return json_to_py(response)

--- a/lib/createsend/subscriber.py
+++ b/lib/createsend/subscriber.py
@@ -26,7 +26,7 @@ class Subscriber(CreateSendBase):
 
     def add(self, list_id, email_address, name, custom_fields, resubscribe, consent_to_track, restart_subscription_based_autoresponders=False):
         """Adds a subscriber to a subscriber list."""
-        validate_consent_to_track(consent_to_track)
+        consent_to_track = validate_consent_to_track(consent_to_track)
         body = {
             "EmailAddress": email_address,
             "Name": name,
@@ -34,6 +34,7 @@ class Subscriber(CreateSendBase):
             "Resubscribe": resubscribe,
             "ConsentToTrack": consent_to_track,
             "RestartSubscriptionBasedAutoresponders": restart_subscription_based_autoresponders}
+        print(body)
         response = self._post("/subscribers/%s.json" %
                               list_id, json.dumps(body))
         return json_to_py(response)
@@ -41,7 +42,7 @@ class Subscriber(CreateSendBase):
     def update(self, new_email_address, name, custom_fields, resubscribe, consent_to_track, restart_subscription_based_autoresponders=False):
         """Updates any aspect of a subscriber, including email address, name, and
         custom field data if supplied."""
-        validate_consent_to_track(consent_to_track)
+        consent_to_track = validate_consent_to_track(consent_to_track)
         params = {"email": self.email_address}
         body = {
             "EmailAddress": new_email_address,

--- a/lib/createsend/transactional.py
+++ b/lib/createsend/transactional.py
@@ -30,7 +30,7 @@ class Transactional(CreateSendBase):
 
     def smart_email_send(self, smart_email_id, to, consent_to_track, cc=None, bcc=None, attachments=None, data=None, add_recipients_to_list=None):
         """Sends the smart email."""
-        validate_consent_to_track(consent_to_track)
+        consent_to_track = validate_consent_to_track(consent_to_track)
         body = {
             "To": to,
             "CC": cc,
@@ -46,7 +46,7 @@ class Transactional(CreateSendBase):
 
     def classic_email_send(self, subject, from_address, to, consent_to_track, client_id=None, cc=None, bcc=None, html=None, text=None, attachments=None, track_opens=True, track_clicks=True, inline_css=True, group=None, add_recipients_to_list=None):
         """Sends a classic email."""
-        validate_consent_to_track(consent_to_track)
+        consent_to_track = validate_consent_to_track(consent_to_track)
         body = {
             "Subject": subject,
             "From": from_address,

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -9,7 +9,11 @@ import json
 
 
 
-VALID_CONSENT_TO_TRACK_VALUES = ("yes", "no", "unchanged")
+VALID_CONSENT_TO_TRACK_VALUES = {
+    True: "yes",
+    False: "no",
+    None: "unchanged",
+}
 
 
 class CertificateError(ValueError):
@@ -140,18 +144,25 @@ def dict_to_object(d):
 
 
 def validate_consent_to_track(user_input):
+    """
+    Accept both a nullable bool, and the strings the Campaign Monitor API expects
+    Returns a 'cleaned' value that the API will accept
+    """
     from createsend import ClientError
+    if user_input in VALID_CONSENT_TO_TRACK_VALUES.keys():
+        return VALID_CONSENT_TO_TRACK_VALUES[user_input]
     if hasattr(user_input, 'lower'):
         user_input = user_input.lower()
-    if user_input in VALID_CONSENT_TO_TRACK_VALUES:
-        return
-    raise ClientError("Consent to track value must be one of %s" % (VALID_CONSENT_TO_TRACK_VALUES,))
+    if user_input in VALID_CONSENT_TO_TRACK_VALUES.values():
+        return user_input
+    flattened_values = list(VALID_CONSENT_TO_TRACK_VALUES.keys()) + list(VALID_CONSENT_TO_TRACK_VALUES.values())
+    raise ClientError("Consent to track value must be one of %s" % flattened_values)
 
 
 def get_faker(expected_url, filename, status=None, body=None):
 
     class Faker(object):
-        """Represents a fake web request, including the expected URL, an open 
+        """Represents a fake web request, including the expected URL, an open
         function which reads the expected response from a fixture file, and the
         expected response status code."""
 


### PR DESCRIPTION
 * ``consent_to_track`` parameter also accepts a nullable boolean
 * Added info to README.md about breaking API change

As per issue #62 - allowed consent_to_track parameter to be a boolean, and added info near the top of the README.md which should hopefully help people who upgrade their libraries and find that the API has broken.

I went to add tests, but notice the existing tests don't particularly lend theirselves to testing this (and there aren't any for consent_to_track functionality at the moment).  I can add them if needed, but I manually tested this in Python 2.7, Python 3.4 & Python 3.6 and all works as expected.