### PR TITLE
Add `excludemessagebody` parameter for Transactional message details endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 install:
   - pip install coverage coveralls
 script:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # createsend-python history
 
-## v6.1.1 - 10 Feb, 2021
+## v6.1.2 - 10 Feb, 2021
 * Add `excludemessagebody` parameter for Transactional message details endpoint
   and update tests.
 * Update README with sample code for using message details and timeline endpoint.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # createsend-python history
 
+## v6.1.1 - 10 Feb, 2021
+* Add `excludemessagebody` parameter for Transactional message details endpoint
+  and update tests.
+* Update README with sample code for using message details and timeline endpoint.
+* Add Python 3.8 to `tox.ini`.
+
 ## v6.1.0 - 29 August, 2019
 * Added support for Journeys endpoints
 * This includes client/journeys, journeys/summary and the journeys/email/... endpoints

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ if len(msg_id) == 0:
 
 tx = Transactional(auth)
 
-# Get message details using message id
-msg_details = tx.message_details(msg_id, statistics=True, exclude_message_body=False)
+# Get message details using message id. 
+# We can optionally disable loading the body by setting exclude_message_body to `True`.
+msg_details = tx.message_details(msg_id, statistics=False, exclude_message_body=True)
 print(f'smart email id: {msg_details.SmartEmailID}')
 print(f'bounce type: {msg_details.BounceType}')
 print(f'bounce category: {msg_details.BounceCategory}')

--- a/README.md
+++ b/README.md
@@ -120,6 +120,52 @@ Client: Second Client
   - News for January 2013
 ```
 
+## Transactional
+
+Sample code that uses Transactional message detail and timeline endpoint API.
+```python
+from createsend import Transactional
+import os
+import sys
+
+auth = {'api_key': os.getenv('CREATESEND_API_KEY', '')}
+msg_id = os.getenv('MESSAGE_ID', '')
+
+if len(auth) == 0:
+    print("API Key Not Provided")
+    sys.exit(1)
+
+if len(msg_id) == 0:
+    print("Message ID Not Provided")
+    sys.exit(1)
+
+#auth = {'api_key': '[api_key]'}
+#msg_id = "[message id]" # e.g., becd8473-6a19-1feb-84c5-28d16948a5fc
+
+tx = Transactional(auth)
+
+# Get message details using message id
+msg_details = tx.message_details(msg_id, statistics=True, exclude_message_body=False)
+print(f'smart email id: {msg_details.SmartEmailID}')
+print(f'bounce type: {msg_details.BounceType}')
+print(f'bounce category: {msg_details.BounceCategory}')
+print(f'html: {msg_details.Message.Body.Html}')
+print('--')
+
+# Count the number of bounced mail using message timeline
+msg_timeline = tx.message_timeline()
+num_bounced = 0
+for m in msg_timeline:
+    print('--')
+    print(f'message id: {m.MessageID}')
+    if str.lower(m.Status) == 'bounced':
+        num_bounced += 1
+        print(f'bounce type: {m.BounceType}')
+        print(f'bounce category: {m.BounceCategory}')
+print('--')
+print(f"total bounces: {num_bounced}")
+```
+
 ## Handling errors
 If the Campaign Monitor API returns an error, an exception will be raised. For example, if you attempt to create a campaign and enter empty values for subject and other required fields:
 

--- a/lib/createsend/transactional.py
+++ b/lib/createsend/transactional.py
@@ -90,10 +90,10 @@ class Transactional(CreateSendBase):
         response = self._get("/transactional/messages", params)
         return json_to_py(response)
 
-    def message_details(self, message_id, statistics=False):
+    def message_details(self, message_id, statistics=False, exclude_message_body=False):
         """Gets the details of this message."""
         response = self._get(
-            "/transactional/messages/%s?statistics=%s" % (message_id, statistics))
+            "/transactional/messages/%s?statistics=%s&excludemessagebody=%s" % (message_id, statistics, exclude_message_body))
         return json_to_py(response)
 
     def message_resend(self, message_id):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="createsend",
-    version='6.1.1',
+    version='6.1.2',
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="createsend",
-    version='6.1.0',
+    version='6.1.1',
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',
@@ -45,5 +45,8 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ]
 )

--- a/test/test_transactional.py
+++ b/test/test_transactional.py
@@ -100,15 +100,15 @@ class TransactionalTestCase(object):
         self.assertEqual(timeline[0].SmartEmailID, self.smart_email_id)
 
     def test_message_details(self):
-        self.tx.stub_request('transactional/messages/%s?statistics=False' %
+        self.tx.stub_request('transactional/messages/%s?statistics=False&excludemessagebody=False' %
                              (self.message_id), "tx_message_details.json")
-        msg = self.tx.message_details(self.message_id, statistics=False)
+        msg = self.tx.message_details(self.message_id, statistics=False, exclude_message_body=False)
         self.assertEqual(msg.MessageID, self.message_id)
 
     def test_message_details_with_stats(self):
-        self.tx.stub_request('transactional/messages/%s?statistics=True' %
+        self.tx.stub_request('transactional/messages/%s?statistics=True&excludemessagebody=False' %
                              (self.message_id), "tx_message_details_with_statistics.json")
-        msg = self.tx.message_details(self.message_id, statistics=True)
+        msg = self.tx.message_details(self.message_id, statistics=True, exclude_message_body=False)
         self.assertEqual(len(msg.Opens), 1)
         self.assertEqual(len(msg.Clicks), 1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pip is broken on py32
-envlist = py27, py30, py31, py33, py34, py35, py36, py37
+envlist = py27, py30, py31, py33, py34, py35, py36, py37, py38
 
 [testenv]
 install_command=pip install {packages}


### PR DESCRIPTION
* Add `excludemessagebody` parameter for Transactional message details
endpoint and update tests.
* Update README with sample code for using message details and timeline
endpoint.
* Add Python 3.8 to `tox.ini`.