### PR TITLE
EL-281 -- Update the phyton wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
+  - 3.10
 install:
   - pip install coverage coveralls
 script:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # createsend-python history
 
+## v7.0.0 - 19 Nov, 2021
+* Upgrades to Createsend API v3.3 which includes new breaking changes
+* Breaking: 'client.campaigns', getting sent campaigns returned an object to support pagination
+* Add support for pagination, filtering and sorting to 'client.campaigns'
+* Add new 'client.tags', getting list of tags for the client
+* Add Python 3.10 to `tox.ini`.
+
 ## v6.1.2 - 10 Feb, 2021
 * Add `excludemessagebody` parameter for Transactional message details endpoint
   and update tests.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,10 +2,12 @@
 
 ## v7.0.0 - 19 Nov, 2021
 * Upgrades to Createsend API v3.3 which includes new breaking changes
-* Breaking: 'client.campaigns', getting sent campaigns returned an object to support pagination
-* Add support for pagination, filtering and sorting to 'client.campaigns'
-* Add new 'client.tags', getting list of tags for the client
-* Add Python 3.10 to `tox.ini`.
+* Breaking: 'client.campaigns' now returned an object to support pagination (use .Results to get the array of campaigns)
+* Added 'Tags' as another field that is returned in 'client.scheduled', 'client.drafts' and client.campaigns'
+* Added 'Name' as another filed that is returned in 'campaign.summary'
+* Add new support for 'client.tags' endpoint (ie: getting list of tags for the client)
+* Add support for pagination, filtering and sorting to 'client.campaigns' endpoint
+* Add Python 3.10 to `tox.ini`
 
 ## v6.1.2 - 10 Feb, 2021
 * Add `excludemessagebody` parameter for Transactional message details endpoint

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * Breaking: 'client.campaigns' now returned an object to support pagination (use .Results to get the array of campaigns)
 * Added 'Tags' as another field that is returned in 'client.scheduled', 'client.drafts' and client.campaigns'
-* Added 'Name' as another filed that is returned in 'campaign.summary'
+* Added 'Name' as another field that is returned in 'campaign.summary'
 * Add new support for 'client.tags' endpoint (ie: getting list of tags for the client)
 * Add support for pagination, filtering and sorting to 'client.campaigns' endpoint
 * Add Python 3.10 to `tox.ini`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ clients = cs.clients()
 ```
 
 ## Basic usage
-This example of listing all your clients and their campaigns demonstrates basic usage of the library and the data returned from the API:
+This example of listing all your clients and their draft campaigns demonstrates basic usage of the library and the data returned from the API:
 
 ```python
 from createsend import *
@@ -104,7 +104,7 @@ for cl in clients:
   print("Client: %s" % cl.Name)
   client = Client(auth, cl.ClientID)
   print("- Campaigns:")
-  for cm in client.campaigns().Results:
+  for cm in client.drafts():
     print("  - %s" % cm.Subject)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # createsend
 
-A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 2.7, 3.4, 3.5, 3.6 or 3.7.
+A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9 or 3.10.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ for cl in clients:
   print("Client: %s" % cl.Name)
   client = Client(auth, cl.ClientID)
   print("- Campaigns:")
-  for cm in client.campaigns():
+  for cm in client.campaigns().Results:
     print("  - %s" % cm.Subject)
 ```
 

--- a/lib/createsend/client.py
+++ b/lib/createsend/client.py
@@ -29,9 +29,17 @@ class Client(CreateSendBase):
         response = self._get("/clients/%s.json" % self.client_id)
         return json_to_py(response)
 
-    def campaigns(self):
+    def campaigns(self, sent_from_date="", sent_to_date="", tags="", page=1, page_size=1000, order_direction="desc"):
         """Gets the sent campaigns belonging to this client."""
-        response = self._get(self.uri_for("campaigns"))
+        params = {
+            "sentfromdate": sent_from_date,
+            "senttodate": sent_to_date,
+            "page": page,
+            "tags": tags,
+            "pagesize": page_size,
+            "orderdirection": order_direction,
+        }
+        response = self._get(self.uri_for("campaigns"), params=params)
         return json_to_py(response)
 
     def scheduled(self):
@@ -42,6 +50,11 @@ class Client(CreateSendBase):
     def drafts(self):
         """Gets the draft campaigns belonging to this client."""
         response = self._get(self.uri_for("drafts"))
+        return json_to_py(response)
+
+    def tags(self):
+        """Gets the list of tags belonging to this client."""
+        response = self._get(self.uri_for("tags"))
         return json_to_py(response)
 
     def lists(self):

--- a/lib/createsend/createsend.py
+++ b/lib/createsend/createsend.py
@@ -252,7 +252,7 @@ class CreateSendBase(object):
 
 class CreateSend(CreateSendBase):
     """Provides high level CreateSend functionality/data you'll probably need."""
-    base_uri = "https://api.createsend.com/api/v3.2"
+    base_uri = "https://api.createsend.com/api/v3.3"
     oauth_uri = "https://api.createsend.com/oauth"
     oauth_token_uri = "%s/token" % oauth_uri
     platform = os.getenv('SERVER_SOFTWARE') or platform.platform()

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -171,6 +171,6 @@ def get_faker(expected_url, filename, status=None, body=None):
             if url.startswith("http"):
                 return url
             else:
-                return "https://api.createsend.com/api/v3.2/%s" % url
+                return "https://api.createsend.com/api/v3.3/%s" % url
 
     return Faker(expected_url, filename, status, body)

--- a/samples/campaigns.py
+++ b/samples/campaigns.py
@@ -1,0 +1,13 @@
+from createsend import *
+
+auth = {
+  'access_token': 'YOUR_ACCESS_TOKEN',
+  'refresh_token': 'YOUR_REFRESH_TOKEN' }
+campaignId = 'YOUR_CAMPAIGN_ID'
+
+campaign = Campaign(auth, campaignId)
+
+# Get the summary info for a campaign
+summary = campaign.summary()
+for property, value in vars(summary).items():
+  print(property, ":", value)

--- a/samples/clients.py
+++ b/samples/clients.py
@@ -1,0 +1,40 @@
+from createsend import *
+
+auth = {
+  'access_token': 'YOUR_ACCESS_TOKEN',
+  'refresh_token': 'YOUR_REFRESH_TOKEN' }
+clientId = 'YOUR_CLIENT_ID'
+
+cs = CreateSend(auth)
+client = Client(auth, clientId)
+
+# Get list of sent campaigns
+print("List of sent campaigns:")
+campaigns = []
+pageNumber = 1
+pagedCampaigns = client.campaigns(page = 1)
+numberOfPages = pagedCampaigns.NumberOfPages
+while pageNumber <= numberOfPages:
+  if (pageNumber > 1):
+    pagedCampaigns = client.campaigns(page = pageNumber)
+  
+  print("  Page: %d" % pageNumber)
+  for cm in pagedCampaigns.Results:
+    print("    - %s" % cm.Subject)
+  
+  pageNumber = pageNumber + 1
+
+# Get list of drafts campaigns
+print("List of drafts campaigns:")
+for cm in client.drafts():
+  print("  - %s" % cm.Subject)
+
+# Get list of scheduled campaigns
+print("List of scheduled campaigns:")
+for cm in client.scheduled():
+  print("  - %s" % cm.Subject)
+
+# Get list of tags
+print("List of tags:")
+for tag in client.tags():
+  print("  Tag: %s - NumberOfCampaigns: %d" % (tag.Name, tag.NumberOfCampaigns))

--- a/samples/clients.py
+++ b/samples/clients.py
@@ -5,18 +5,34 @@ auth = {
   'refresh_token': 'YOUR_REFRESH_TOKEN' }
 clientId = 'YOUR_CLIENT_ID'
 
+
 cs = CreateSend(auth)
 client = Client(auth, clientId)
 
 # Get list of sent campaigns
 print("List of sent campaigns:")
-campaigns = []
 pageNumber = 1
 pagedCampaigns = client.campaigns(page = 1)
 numberOfPages = pagedCampaigns.NumberOfPages
 while pageNumber <= numberOfPages:
   if (pageNumber > 1):
     pagedCampaigns = client.campaigns(page = pageNumber)
+  
+  print("  Page: %d" % pageNumber)
+  for cm in pagedCampaigns.Results:
+    print("    - %s" % cm.Subject)
+  
+  pageNumber = pageNumber + 1
+
+  
+# Get list of sent campaigns filtered by tags and date
+print("List of sent campaigns at 2021 with ABTest tag:")
+pageNumber = 1
+pagedCampaigns = client.campaigns(page = 1, sent_from_date="2021-01-01", sent_to_date="2022-01-01", tags="ABTest")
+numberOfPages = pagedCampaigns.NumberOfPages
+while pageNumber <= numberOfPages:
+  if (pageNumber > 1):
+    pagedCampaigns = client.campaigns(page = pageNumber, sent_from_date="2021-01-01", sent_to_date="2022-01-01", tags="ABTest")
   
   print("  Page: %d" % pageNumber)
   for cm in pagedCampaigns.Results:

--- a/samples/general.py
+++ b/samples/general.py
@@ -1,0 +1,12 @@
+from createsend import *
+
+auth = {
+  'access_token': 'YOUR_ACCESS_TOKEN',
+  'refresh_token': 'YOUR_REFRESH_TOKEN' }
+
+cs = CreateSend(auth)
+clients = cs.clients()
+
+# Get list of clients 
+for cl in clients:
+  print("Client: %s - Id: %s" % (cl.Name, cl.ClientID))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="createsend",
-    version='6.1.2',
+    version='7.0.0',
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',
@@ -48,5 +48,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ]
 )

--- a/test/fixtures/campaign_summary.json
+++ b/test/fixtures/campaign_summary.json
@@ -1,4 +1,5 @@
 {
+  "Name": "Last Campaign",
   "Recipients": 5,
   "TotalOpened": 10,
   "Clicks": 0,

--- a/test/fixtures/campaigns.json
+++ b/test/fixtures/campaigns.json
@@ -1,26 +1,36 @@
-[
-  {
-    "WebVersionURL": "http://createsend.com/t/r-765E86829575EE2C",
-    "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
-    "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
-    "Subject": "Campaign One",
-    "Name": "Campaign One",
-    "FromName": "My Name",
-    "FromEmail": "myemail@example.com",
-    "ReplyTo": "myemail@example.com",
-    "SentDate": "2010-10-12 12:58:00",
-    "TotalRecipients": 2245
-  },
-  {
-    "WebVersionURL": "http://createsend.com/t/r-DD543566A87C9B8B",
-    "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
-    "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
-    "Subject": "Campaign Two",
-    "Name": "Campaign Two",
-    "FromName": "My Name",
-    "FromEmail": "myemail@example.com",
-    "ReplyTo": "myemail@example.com",
-    "SentDate": "2010-10-06 16:20:00",
-    "TotalRecipients": 11222
-  }
-]
+{
+    "Results": [
+      {
+        "WebVersionURL": "http://createsend.com/t/r-765E86829575EE2C",
+        "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
+        "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
+        "Subject": "Campaign One",
+        "Name": "Campaign One",
+        "FromName": "My Name",
+        "FromEmail": "myemail@example.com",
+        "ReplyTo": "myemail@example.com",
+        "SentDate": "2010-10-12 12:58:00",
+        "TotalRecipients": 2245,
+        "Tags": ["Tag1", "Tag2"]
+      },
+      {
+        "WebVersionURL": "http://createsend.com/t/r-DD543566A87C9B8B",
+        "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
+        "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
+        "Subject": "Campaign Two",
+        "Name": "Campaign Two",
+        "FromName": "My Name",
+        "FromEmail": "myemail@example.com",
+        "ReplyTo": "myemail@example.com",
+        "SentDate": "2010-10-06 16:20:00",
+        "TotalRecipients": 11222
+      }
+    ],
+    "ResultsOrderedBy": "SentDate",
+    "OrderDirection": "desc",
+    "PageNumber": 1,
+    "PageSize": 2,
+    "RecordsOnThisPage": 2,
+    "TotalNumberOfRecords": 49,
+    "NumberOfPages": 25
+}

--- a/test/fixtures/drafts.json
+++ b/test/fixtures/drafts.json
@@ -8,7 +8,8 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
     "PreviewURL": "http://createsend.com/t/r-E97A7BB2E6983DA1",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "Tags": ["Tags5"]
   },
   {
     "CampaignID": "2e928e982065d92627139208c8c01db1",
@@ -19,6 +20,7 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
     "PreviewURL": "http://createsend.com/t/r-E97A7BB2E6983DA1",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t"
+    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "Tags": []
   }
 ]

--- a/test/fixtures/scheduled_campaigns.json
+++ b/test/fixtures/scheduled_campaigns.json
@@ -10,7 +10,8 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:37:00",
     "PreviewURL": "http://createsend.com/t/r-DD543521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t"
+    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t",
+    "Tags": []
   },
   {
     "DateScheduled": "2011-05-29 11:20:00",
@@ -23,6 +24,7 @@
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:39:00",
     "PreviewURL": "http://createsend.com/t/r-DD913521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t"
+    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t",
+    "Tags": ["Tags3", "Tags4"]
   }
 ]

--- a/test/fixtures/tags.json
+++ b/test/fixtures/tags.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Name": "Happy",
+    "NumberOfCampaigns": 3
+  },
+  {
+    "Name": "Sad",
+    "NumberOfCampaigns": 1
+  }
+]

--- a/test/test_campaign.py
+++ b/test/test_campaign.py
@@ -145,6 +145,7 @@ class CampaignTestCase(object):
         self.campaign.stub_request(
             "campaigns/%s/summary.json" % self.campaign_id, "campaign_summary.json")
         summary = self.campaign.summary()
+        self.assertEquals(summary.Name, "Last Campaign")
         self.assertEquals(summary.Recipients, 5)
         self.assertEquals(summary.TotalOpened, 10)
         self.assertEquals(summary.Clicks, 0)

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -28,9 +28,10 @@ class ClientTestCase(object):
         self.assertEquals(cl.BillingDetails.Credits, 500)
 
     def test_campaigns(self):
-        self.cl.stub_request("clients/%s/campaigns.json" %
+        self.cl.stub_request("clients/%s/campaigns.json?sentfromdate=&senttodate=&page=1&tags=&pagesize=1000&orderdirection=desc" %
                              self.cl.client_id, "campaigns.json")
-        campaigns = self.cl.campaigns()
+        sentCampaigns = self.cl.campaigns()
+        campaigns = sentCampaigns.Results
         self.assertEquals(len(campaigns), 2)
         self.assertEquals(campaigns[0].CampaignID,
                           'fc0ce7105baeaf97f47c99be31d02a91')
@@ -45,6 +46,14 @@ class ClientTestCase(object):
         self.assertEquals(campaigns[0].FromName, 'My Name')
         self.assertEquals(campaigns[0].FromEmail, 'myemail@example.com')
         self.assertEquals(campaigns[0].ReplyTo, 'myemail@example.com')
+        self.assertEquals(campaigns[0].Tags, ["Tag1", "Tag2"])
+        self.assertEquals(sentCampaigns.ResultsOrderedBy, "SentDate")
+        self.assertEquals(sentCampaigns.OrderDirection, "desc")
+        self.assertEquals(sentCampaigns.PageNumber, 1)
+        self.assertEquals(sentCampaigns.PageSize, 2)
+        self.assertEquals(sentCampaigns.RecordsOnThisPage, 2)
+        self.assertEquals(sentCampaigns.TotalNumberOfRecords, 49)
+        self.assertEquals(sentCampaigns.NumberOfPages, 25)
 
     def test_scheduled(self):
         self.cl.stub_request("clients/%s/scheduled.json" %
@@ -66,6 +75,7 @@ class ClientTestCase(object):
         self.assertEquals(campaigns[0].FromName, 'My Name')
         self.assertEquals(campaigns[0].FromEmail, 'myemail@example.com')
         self.assertEquals(campaigns[0].ReplyTo, 'myemail@example.com')
+        self.assertEquals(campaigns[0].Tags, [])
 
     def test_drafts(self):
         self.cl.stub_request("clients/%s/drafts.json" %
@@ -84,6 +94,17 @@ class ClientTestCase(object):
         self.assertEquals(drafts[0].FromName, 'My Name')
         self.assertEquals(drafts[0].FromEmail, 'myemail@example.com')
         self.assertEquals(drafts[0].ReplyTo, 'myemail@example.com')
+        self.assertEquals(drafts[0].Tags, ["Tags5"])
+    
+    def test_tags(self):
+        self.cl.stub_request("clients/%s/tags.json" %
+                             self.cl.client_id, "tags.json")
+        tags = self.cl.tags()
+        self.assertEquals(len(tags), 2)
+        self.assertEquals(tags[0].Name, 'Happy')
+        self.assertEquals(tags[0].NumberOfCampaigns, 3)
+        self.assertEquals(tags[1].Name, 'Sad')
+        self.assertEquals(tags[1].NumberOfCampaigns, 1)
 
     def test_lists(self):
         self.cl.stub_request("clients/%s/lists.json" %

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pip is broken on py32
-envlist = py27, py30, py31, py33, py34, py35, py36, py37, py38
+envlist = py27, py30, py31, py33, py34, py35, py36, py37, py38, py39, py310
 
 [testenv]
 install_command=pip install {packages}


### PR DESCRIPTION
* Update Phyton wrapper to use 3.3 endpoints 
* Update returned response for scheduled, drafts and sent to include tags info (no type thus we should get it for free, manually tested that it returns the tags info)
* Add support for pagination, sorting and filtering in sent method (there are default filter input otherwise)
* Add new endpoint for Tags 
* Get Campaign Summary also returns name (no type thus we should get it for free, manually tested that it return the name)
* Update any relevant tests (including the tags value from the above endpoints, as well as the name)
* Publish/versioning (increase as a major version as it contains a breaking changes)