### PR TITLE
Python 3.12+ compatibility - module 'ssl' has no attribute 'wrap_socket'

### DIFF
--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -106,7 +106,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             context = ssl.SSLContext()
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_verify_locations(cert_path)
-            if self.cert_file and self.key_file:
+            if hasattr(self, 'cert_file') and hasattr(self, 'key_file') and self.cert_file and self.key_file:
                 context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
             self.sock = context.wrap_socket(sock)
         else:

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -101,12 +101,21 @@ class VerifiedHTTPSConnection(HTTPSConnection):
 
         cert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
-        self.sock = ssl.wrap_socket(
-            sock,
-            self.key_file,
-            self.cert_file,
-            cert_reqs=ssl.CERT_REQUIRED,
-            ca_certs=cert_path)
+        # for >= py3.7, mandatory since 3.12
+        if hasattr(ssl.SSLContext, 'wrap_socket'):
+            context = ssl.SSLContext()
+            context.verify_mode = ssl.CERT_REQUIRED
+            context.load_verify_locations(cert_path)
+            if self.cert_file and self.key_file:
+                context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
+            self.sock = context.wrap_socket(sock)
+        else:
+            self.sock = ssl.wrap_socket(
+                sock,
+                self.key_file,
+                self.cert_file,
+                cert_reqs=ssl.CERT_REQUIRED,
+                ca_certs=cert_path)
 
         try:
             match_hostname(self.sock.getpeercert(), self.host)


### PR DESCRIPTION
ssl.wrap_socket was deprecated since Python 3.7 and remove in 3.12 so for it to work with 3.12 SSLContext.wrap_socket has to be used.

https://pradyunsg-cpython-lutra-testing.readthedocs.io/en/latest/whatsnew/3.12.html

Tested for my use case and it seems to be working fine, although did not test with self.key_file/self.cert_file set which were undefined (and None in some test).