### PR TITLE
Documentation updates to increase wrapper version to 8.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 python:
-  - 2.7
-  - 3.4
-  - 3.5
   - 3.6
   - 3.7
   - 3.8
   - 3.9
   - 3.10
+  - 3.11
+  - 3.12
+  - 3.13
 install:
   - pip install coverage coveralls
 script:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # createsend-python history
 
-# v8.0.0 - 4 Dec, 2024
+## v8.0.0 - 4 Dec, 2024
 * Upgrades to allow this wrapper to be used with Python 3.12 and beyond.
 * Breaking: Python versions 3.5 and prior will no longer work with this version of the wrapper.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # createsend-python history
 
+# v8.0.0 - 4 Dec, 2024
+* Upgrades to allow this wrapper to be used with Python 3.12 and beyond.
+* Breaking: Python versions 3.5 and prior will no longer work with this version of the wrapper.
+
 ## v7.0.0 - 15 Dec, 2021
 * Upgrades to Createsend API v3.3 which includes new breaking changes
 * Breaking: 'client.campaigns' now returned an object to support pagination (use .Results to get the array of campaigns)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # createsend
 
-A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9 or 3.10.
+A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 or later.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="createsend",
-    version='7.0.0',
+    version='8.0.0',
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',
@@ -35,20 +35,16 @@ setup(
 
         # Generally, we support the following.
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
 
         # Specifically, we support the following releases.
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.0",
-        "Programming Language :: Python :: 3.1",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pip is broken on py32
-envlist = py36, py37, py38, py39, py310
+envlist = py36, py37, py38, py39, py310, py311, py312, py313
 
 [testenv]
 install_command=pip install {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pip is broken on py32
-envlist = py27, py30, py31, py33, py34, py35, py36, py37, py38, py39, py310
+envlist = py36, py37, py38, py39, py310
 
 [testenv]
 install_command=pip install {packages}


### PR DESCRIPTION
Thanks to https://github.com/campaignmonitor/createsend-python/pull/78, this wrapper is now usable with versions of Python 3.12 and above.

This PR updates the version of the `createsend-python` package.