### PR TITLE
Updated release steps

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # createsend-python history
 
+## v8.0.0 - 5 Dec, 2024
+* No changes to actual wrapper code.
+* Release steps updated.
+
 ## v8.0.0 - 4 Dec, 2024
 * Upgrades to allow this wrapper to be used with Python 3.12 and beyond.
 * Breaking: Python versions 3.5 and prior will no longer work with this version of the wrapper.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,10 @@
 ## Requirements
 
 - You must have a [PyPI](https://pypi.python.org/pypi) account and must be an owner or maintainer of the [createsend](https://pypi.python.org/pypi/createsend/) package.
+- You must install [Twine](https://pypi.org/project/twine/)
+```
+pip install twine
+```
 
 ## Prepare the release
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,11 @@ end
 
 desc "Build and release a source distribution"
 task :release do
-  system "python setup.py sdist upload"
-  system "python setup.py bdist_wheel upload"
+    # Create source and wheel distributions
+    system "python setup.py sdist bdist_wheel"
+
+    # Upload using Twine
+    system "python -m twine upload dist/*"
 end
 
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -13,11 +13,11 @@ end
 
 desc "Build and release a source distribution"
 task :release do
-    # Create source and wheel distributions
-    system "python setup.py sdist bdist_wheel"
+  # Create source and wheel distributions
+  system "python setup.py sdist bdist_wheel"
 
-    # Upload using Twine
-    system "python -m twine upload dist/*"
+  # Upload using Twine
+  system "python -m twine upload dist/*"
 end
 
 task :default => :test

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="createsend",
-    version='8.0.0',
+    version='8.0.1',
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         'six>=1.10',
     ],
-    test_suite='test',
     packages=find_packages('lib'),
     package_dir={'': 'lib'},
     package_data={'': ['cacert.pem']},


### PR DESCRIPTION
During the release process recently, I encountered some issues. This PR is to bring the release portions of the wrapper along with release documentation up to date.

## Issue 1

There was this warning:
```
Unknown distribution option: 'test_suite'
```

This warning indicates that `test_suite` is no longer a recognized option in setup.py with newer versions of setuptools.

To overcome this, this option was removed from `setup.py`

## Issue 2

This error:
```
error: invalid command 'upload'
```

The upload command in the Rakefile was deprecated and needed to be replaced with twine.

To overcome this, the Rakefile was updated to use [Twine](https://pypi.org/project/twine/).