### PR TITLE
Remove old python code

### DIFF
--- a/lib/createsend/__init__.py
+++ b/lib/createsend/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-
-# -*- coding: utf-8 -*-
 __title__ = 'createsend-python'
 __author__ = 'Campaign Monitor'
 __license__ = 'MIT'

--- a/lib/createsend/administrator.py
+++ b/lib/createsend/administrator.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -11,7 +9,7 @@ class Administrator(CreateSendBase):
 
     def __init__(self, auth=None, email_address=None):
         self.email_address = email_address
-        super(Administrator, self).__init__(auth)
+        super().__init__(auth)
 
     def get(self, email_address=None):
         """Gets an administrator by  email address."""

--- a/lib/createsend/campaign.py
+++ b/lib/createsend/campaign.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -11,7 +9,7 @@ class Campaign(CreateSendBase):
 
     def __init__(self, auth=None, campaign_id=None):
         self.campaign_id = campaign_id
-        super(Campaign, self).__init__(auth)
+        super().__init__(auth)
 
     def create(self, client_id, subject, name, from_name, from_email, reply_to, html_url,
                text_url, list_ids, segment_ids):
@@ -190,4 +188,4 @@ class Campaign(CreateSendBase):
         return json_to_py(response)
 
     def uri_for(self, action):
-        return "/campaigns/%s/%s.json" % (self.campaign_id, action)
+        return "/campaigns/{}/{}.json".format(self.campaign_id, action)

--- a/lib/createsend/campaign.py
+++ b/lib/createsend/campaign.py
@@ -188,4 +188,4 @@ class Campaign(CreateSendBase):
         return json_to_py(response)
 
     def uri_for(self, action):
-        return "/campaigns/{}/{}.json".format(self.campaign_id, action)
+        return f"/campaigns/{self.campaign_id}/{action}.json"

--- a/lib/createsend/client.py
+++ b/lib/createsend/client.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -11,7 +9,7 @@ class Client(CreateSendBase):
 
     def __init__(self, auth=None, client_id=None):
         self.client_id = client_id
-        super(Client, self).__init__(auth)
+        super().__init__(auth)
 
     def create(self, company, timezone, country):
         """Creates a client."""
@@ -186,4 +184,4 @@ class Client(CreateSendBase):
         return json_to_py(response)
 
     def uri_for(self, action):
-        return "/clients/%s/%s.json" % (self.client_id, action)
+        return "/clients/{}/{}.json".format(self.client_id, action)

--- a/lib/createsend/client.py
+++ b/lib/createsend/client.py
@@ -184,4 +184,4 @@ class Client(CreateSendBase):
         return json_to_py(response)
 
     def uri_for(self, action):
-        return "/clients/{}/{}.json".format(self.client_id, action)
+        return f"/clients/{self.client_id}/{action}.json"

--- a/lib/createsend/createsend.py
+++ b/lib/createsend/createsend.py
@@ -24,7 +24,7 @@ class CreateSendError(Exception):
         # self.data should contain Code, Message and optionally ResultData
         extra = ("\nExtra result data: %s" % self.data.ResultData) if hasattr(
             self.data, 'ResultData') else ""
-        return "The CreateSend API responded with the following error - {}: {}{}".format(self.data.Code, self.data.Message, extra)
+        return f"The CreateSend API responded with the following error - {self.data.Code}: {self.data.Message}{extra}"
 
 
 class ClientError(Exception):
@@ -75,7 +75,7 @@ class CreateSendBase:
         ]
         if state:
             params.append(('state', state))
-        return "{}?{}".format(CreateSend.oauth_uri, urlencode(params))
+        return f"{CreateSend.oauth_uri}?{urlencode(params)}"
 
     def exchange_token(self, client_id, client_secret, redirect_uri, code):
         """Exchange a provided OAuth code for an OAuth access token, 'expires in'
@@ -93,7 +93,7 @@ class CreateSendBase:
         r = json_to_py(response)
         if hasattr(r, 'error') and hasattr(r, 'error_description'):
             err = "Error exchanging code for access token: "
-            err += "{} - {}".format(r.error, r.error_description)
+            err += f"{r.error} - {r.error_description}"
             raise Exception(err)
         access_token, expires_in, refresh_token = r.access_token, r.expires_in, r.refresh_token
         return [access_token, expires_in, refresh_token]
@@ -154,7 +154,7 @@ class CreateSendBase:
     overridden (e.g. when using the apikey route with username and password)."""
         if username and password:
             headers['Authorization'] = "Basic %s" % base64.b64encode(
-                ("{}:{}".format(username, password)).encode()).decode()
+                (f"{username}:{password}").encode()).decode()
         elif self.auth_details:
             if 'api_key' in self.auth_details and self.auth_details['api_key']:
                 headers['Authorization'] = "Basic %s" % base64.b64encode(

--- a/lib/createsend/journey.py
+++ b/lib/createsend/journey.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from createsend.createsend import CreateSendBase
 from createsend.utils import json_to_py
 
@@ -9,7 +7,7 @@ class Journey(CreateSendBase):
 
     def __init__(self, auth=None, journey_id=None):
         self.journey_id = journey_id
-        super(Journey, self).__init__(auth)
+        super().__init__(auth)
 
     def summary(self):
         """Gets the summary of the journey"""

--- a/lib/createsend/journey_email.py
+++ b/lib/createsend/journey_email.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from createsend.createsend import CreateSendBase
 from createsend.utils import json_to_py
 
@@ -9,7 +7,7 @@ class JourneyEmail(CreateSendBase):
 
     def __init__(self, auth=None, journey_email_id=None):
         self.journey_email_id = journey_email_id
-        super(JourneyEmail, self).__init__(auth)
+        super().__init__(auth)
 
     def bounces(self, date=None, page=None, page_size=None, order_direction=None):
         """Retrieves the bounces for this journey email."""
@@ -46,5 +44,5 @@ class JourneyEmail(CreateSendBase):
         return json_to_py(response)
 
     def uri_for(self, action):
-        return "/journeys/email/%s/%s.json" % (self.journey_email_id, action)
+        return "/journeys/email/{}/{}.json".format(self.journey_email_id, action)
 

--- a/lib/createsend/journey_email.py
+++ b/lib/createsend/journey_email.py
@@ -44,5 +44,5 @@ class JourneyEmail(CreateSendBase):
         return json_to_py(response)
 
     def uri_for(self, action):
-        return "/journeys/email/{}/{}.json".format(self.journey_email_id, action)
+        return f"/journeys/email/{self.journey_email_id}/{action}.json"
 

--- a/lib/createsend/list.py
+++ b/lib/createsend/list.py
@@ -1,7 +1,5 @@
-from __future__ import absolute_import
-
 import json
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 from createsend.createsend import CreateSendBase
 from createsend.utils import json_to_py
@@ -12,7 +10,7 @@ class List(CreateSendBase):
 
     def __init__(self, auth=None, list_id=None):
         self.list_id = list_id
-        super(List, self).__init__(auth)
+        super().__init__(auth)
 
     def create(self, client_id, title, unsubscribe_page, confirmed_opt_in,
                confirmation_success_page, unsubscribe_setting="AllClientLists"):
@@ -206,4 +204,4 @@ class List(CreateSendBase):
             "webhooks/%s/deactivate" % webhook_id), ' ')
 
     def uri_for(self, action):
-        return "/lists/%s/%s.json" % (self.list_id, action)
+        return "/lists/{}/{}.json".format(self.list_id, action)

--- a/lib/createsend/list.py
+++ b/lib/createsend/list.py
@@ -204,4 +204,4 @@ class List(CreateSendBase):
             "webhooks/%s/deactivate" % webhook_id), ' ')
 
     def uri_for(self, action):
-        return "/lists/{}/{}.json".format(self.list_id, action)
+        return f"/lists/{self.list_id}/{action}.json"

--- a/lib/createsend/person.py
+++ b/lib/createsend/person.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -12,7 +10,7 @@ class Person(CreateSendBase):
     def __init__(self, auth=None, client_id=None, email_address=None):
         self.client_id = client_id
         self.email_address = email_address
-        super(Person, self).__init__(auth)
+        super().__init__(auth)
 
     def get(self, client_id=None, email_address=None):
         """Gets a person by client ID and email address."""

--- a/lib/createsend/segment.py
+++ b/lib/createsend/segment.py
@@ -61,4 +61,4 @@ class Segment(CreateSendBase):
         response = self._delete("/segments/%s.json" % self.segment_id)
 
     def uri_for(self, action):
-        return "/segments/{}/{}.json".format(self.segment_id, action)
+        return f"/segments/{self.segment_id}/{action}.json"

--- a/lib/createsend/segment.py
+++ b/lib/createsend/segment.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -11,7 +9,7 @@ class Segment(CreateSendBase):
 
     def __init__(self, auth=None, segment_id=None):
         self.segment_id = segment_id
-        super(Segment, self).__init__(auth)
+        super().__init__(auth)
 
     def create(self, list_id, title, rulegroups):
         """Creates a new segment."""
@@ -63,4 +61,4 @@ class Segment(CreateSendBase):
         response = self._delete("/segments/%s.json" % self.segment_id)
 
     def uri_for(self, action):
-        return "/segments/%s/%s.json" % (self.segment_id, action)
+        return "/segments/{}/{}.json".format(self.segment_id, action)

--- a/lib/createsend/subscriber.py
+++ b/lib/createsend/subscriber.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase, BadRequest
@@ -12,7 +10,7 @@ class Subscriber(CreateSendBase):
     def __init__(self, auth=None, list_id=None, email_address=None):
         self.list_id = list_id
         self.email_address = email_address
-        super(Subscriber, self).__init__(auth)
+        super().__init__(auth)
 
     def get(self, list_id=None, email_address=None, include_tracking_preference=False):
         """Gets a subscriber by list ID and email address."""

--- a/lib/createsend/template.py
+++ b/lib/createsend/template.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -11,7 +9,7 @@ class Template(CreateSendBase):
 
     def __init__(self, auth=None, template_id=None):
         self.template_id = template_id
-        super(Template, self).__init__(auth)
+        super().__init__(auth)
 
     def create(self, client_id, name, html_url, zip_url):
         """Creates a new email template."""

--- a/lib/createsend/transactional.py
+++ b/lib/createsend/transactional.py
@@ -18,7 +18,7 @@ class Transactional(CreateSendBase):
                 "/transactional/smartEmail?status=%s" % status)
         else:
             response = self._get(
-                "/transactional/smartEmail?status={}&clientID={}".format(status, client_id))
+                f"/transactional/smartEmail?status={status}&clientID={client_id}")
         return json_to_py(response)
 
     def smart_email_details(self, smart_email_id):
@@ -91,7 +91,7 @@ class Transactional(CreateSendBase):
     def message_details(self, message_id, statistics=False, exclude_message_body=False):
         """Gets the details of this message."""
         response = self._get(
-            "/transactional/messages/{}?statistics={}&excludemessagebody={}".format(message_id, statistics, exclude_message_body))
+            f"/transactional/messages/{message_id}?statistics={statistics}&excludemessagebody={exclude_message_body}")
         return json_to_py(response)
 
     def message_resend(self, message_id):

--- a/lib/createsend/transactional.py
+++ b/lib/createsend/transactional.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 
 from createsend.createsend import CreateSendBase
@@ -11,7 +9,7 @@ class Transactional(CreateSendBase):
 
     def __init__(self, auth=None, client_id=None):
         self.client_id = client_id
-        super(Transactional, self).__init__(auth)
+        super().__init__(auth)
 
     def smart_email_list(self, status="all", client_id=None):
         """Gets the smart email list."""
@@ -20,7 +18,7 @@ class Transactional(CreateSendBase):
                 "/transactional/smartEmail?status=%s" % status)
         else:
             response = self._get(
-                "/transactional/smartEmail?status=%s&clientID=%s" % (status, client_id))
+                "/transactional/smartEmail?status={}&clientID={}".format(status, client_id))
         return json_to_py(response)
 
     def smart_email_details(self, smart_email_id):
@@ -93,7 +91,7 @@ class Transactional(CreateSendBase):
     def message_details(self, message_id, statistics=False, exclude_message_body=False):
         """Gets the details of this message."""
         response = self._get(
-            "/transactional/messages/%s?statistics=%s&excludemessagebody=%s" % (message_id, statistics, exclude_message_body))
+            "/transactional/messages/{}?statistics={}&excludemessagebody={}".format(message_id, statistics, exclude_message_body))
         return json_to_py(response)
 
     def message_resend(self, message_id):

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import
-
 import os
 import re
-from six.moves.http_client import HTTPSConnection
+from http.client import HTTPSConnection
 import socket
 import ssl
 import json
@@ -154,12 +152,12 @@ def validate_consent_to_track(user_input):
         user_input = user_input.lower()
     if user_input in VALID_CONSENT_TO_TRACK_VALUES:
         return
-    raise ClientError("Consent to track value must be one of %s" % (VALID_CONSENT_TO_TRACK_VALUES,))
+    raise ClientError("Consent to track value must be one of {}".format(VALID_CONSENT_TO_TRACK_VALUES))
 
 
 def get_faker(expected_url, filename, status=None, body=None):
 
-    class Faker(object):
+    class Faker:
         """Represents a fake web request, including the expected URL, an open 
         function which reads the expected response from a fixture file, and the
         expected response status code."""
@@ -172,7 +170,7 @@ def get_faker(expected_url, filename, status=None, body=None):
 
         def open(self):
             if self.filename:
-                return open("%s/../test/fixtures/%s" % (os.path.dirname(os.path.dirname(__file__)), self.filename), mode='rb').read()
+                return open("{}/../test/fixtures/{}".format(os.path.dirname(os.path.dirname(__file__)), self.filename), mode='rb').read()
             else:
                 return ''
 

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -99,21 +99,12 @@ class VerifiedHTTPSConnection(HTTPSConnection):
 
         cert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
-        # for >= py3.7, mandatory since 3.12
-        if hasattr(ssl.SSLContext, 'wrap_socket'):
-            context = ssl.SSLContext()
-            context.verify_mode = ssl.CERT_REQUIRED
-            context.load_verify_locations(cert_path)
-            if hasattr(self, 'cert_file') and hasattr(self, 'key_file') and self.cert_file and self.key_file:
-                context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
-            self.sock = context.wrap_socket(sock)
-        else:
-            self.sock = ssl.wrap_socket(
-                sock,
-                self.key_file,
-                self.cert_file,
-                cert_reqs=ssl.CERT_REQUIRED,
-                ca_certs=cert_path)
+        context = ssl.SSLContext()
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.load_verify_locations(cert_path)
+        if hasattr(self, 'cert_file') and hasattr(self, 'key_file') and self.cert_file and self.key_file:
+            context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
+        self.sock = context.wrap_socket(sock)
 
         try:
             match_hostname(self.sock.getpeercert(), self.host)

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -143,7 +143,7 @@ def validate_consent_to_track(user_input):
         user_input = user_input.lower()
     if user_input in VALID_CONSENT_TO_TRACK_VALUES:
         return
-    raise ClientError("Consent to track value must be one of {}".format(VALID_CONSENT_TO_TRACK_VALUES))
+    raise ClientError(f"Consent to track value must be one of {VALID_CONSENT_TO_TRACK_VALUES}")
 
 
 def get_faker(expected_url, filename, status=None, body=None):
@@ -161,7 +161,7 @@ def get_faker(expected_url, filename, status=None, body=None):
 
         def open(self):
             if self.filename:
-                return open("{}/../test/fixtures/{}".format(os.path.dirname(os.path.dirname(__file__)), self.filename), mode='rb').read()
+                return open(f"{os.path.dirname(os.path.dirname(__file__))}/../test/fixtures/{self.filename}", mode='rb').read()
             else:
                 return ''
 

--- a/samples/general.py
+++ b/samples/general.py
@@ -9,4 +9,4 @@ clients = cs.clients()
 
 # Get list of clients 
 for cl in clients:
-  print("Client: {} - Id: {}".format(cl.Name, cl.ClientID))
+  print(f"Client: {cl.Name} - Id: {cl.ClientID}")

--- a/samples/general.py
+++ b/samples/general.py
@@ -9,4 +9,4 @@ clients = cs.clients()
 
 # Get list of clients 
 for cl in clients:
-  print("Client: %s - Id: %s" % (cl.Name, cl.ClientID))
+  print("Client: {} - Id: {}".format(cl.Name, cl.ClientID))

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,6 @@ setup(
     url="http://campaignmonitor.github.io/createsend-python/",
     license="MIT",
     keywords="createsend campaign monitor email",
-    install_requires=[
-        'six>=1.10',
-    ],
     packages=find_packages('lib'),
     package_dir={'': 'lib'},
     package_data={'': ['cacert.pem']},

--- a/test/test_administrator.py
+++ b/test/test_administrator.py
@@ -1,40 +1,40 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.administrator import Administrator
 
 
-class AdministratorTestCase(object):
+class AdministratorTestCase:
 
     def test_get(self):
         email = "admin@example.com"
         self.administrator.stub_request(
             "admins.json?email=%s" % quote(email), "admin_details.json")
         administrator = self.administrator.get(email)
-        self.assertEquals(administrator.EmailAddress, email)
-        self.assertEquals(administrator.Name, "Admin One")
-        self.assertEquals(administrator.Status, "Active")
+        self.assertEqual(administrator.EmailAddress, email)
+        self.assertEqual(administrator.Name, "Admin One")
+        self.assertEqual(administrator.Status, "Active")
 
     def test_get_without_args(self):
         email = "admin@example.com"
         self.administrator.stub_request(
             "admins.json?email=%s" % quote(email), "admin_details.json")
         administrator = self.administrator.get()
-        self.assertEquals(administrator.EmailAddress, email)
-        self.assertEquals(administrator.Name, "Admin One")
-        self.assertEquals(administrator.Status, "Active")
+        self.assertEqual(administrator.EmailAddress, email)
+        self.assertEqual(administrator.Name, "Admin One")
+        self.assertEqual(administrator.Status, "Active")
 
     def test_add(self):
         self.administrator.stub_request("admins.json", "add_admin.json")
         result = self.administrator.add("admin@example.com", "Admin Name")
-        self.assertEquals(result.EmailAddress, "admin@example.com")
+        self.assertEqual(result.EmailAddress, "admin@example.com")
 
     def test_update(self):
         new_email = "new_email_address@example.com"
         self.administrator.stub_request("admins.json?email=%s" % quote(
             self.administrator.email_address), None)
         self.administrator.update(new_email, "Admin New Name")
-        self.assertEquals(self.administrator.email_address, new_email)
+        self.assertEqual(self.administrator.email_address, new_email)
 
     def test_delete(self):
         self.administrator.stub_request("admins.json?email=%s" % quote(

--- a/test/test_authentication.py
+++ b/test/test_authentication.py
@@ -24,7 +24,7 @@ class AuthenticationTestCase(unittest.TestCase):
             scope=scope,
             state=state
         )
-        self.assertEquals(authorize_url,
+        self.assertEqual(authorize_url,
                           "https://api.createsend.com/oauth?client_id=8998879&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&scope=ViewReports%2CCreateCampaigns%2CSendCampaigns&state=89879287"
                           )
 
@@ -39,7 +39,7 @@ class AuthenticationTestCase(unittest.TestCase):
             redirect_uri=redirect_uri,
             scope=scope
         )
-        self.assertEquals(authorize_url,
+        self.assertEqual(authorize_url,
                           "https://api.createsend.com/oauth?client_id=8998879&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&scope=ViewReports%2CCreateCampaigns%2CSendCampaigns"
                           )
 
@@ -57,11 +57,11 @@ class AuthenticationTestCase(unittest.TestCase):
             redirect_uri=redirect_uri,
             code=code
         )
-        self.assertEquals(self.cs.faker.actual_body,
+        self.assertEqual(self.cs.faker.actual_body,
                           "grant_type=authorization_code&client_id=8998879&client_secret=iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&code=98uqw9d8qu9wdu")
-        self.assertEquals(access_token, "SlAV32hkKG")
-        self.assertEquals(expires_in, 1209600)
-        self.assertEquals(refresh_token, "tGzv3JOkF0XG5Qx2TlKWIA")
+        self.assertEqual(access_token, "SlAV32hkKG")
+        self.assertEqual(expires_in, 1209600)
+        self.assertEqual(refresh_token, "tGzv3JOkF0XG5Qx2TlKWIA")
 
     def test_echange_token_failure(self):
         client_id = 8998879
@@ -73,24 +73,24 @@ class AuthenticationTestCase(unittest.TestCase):
             "https://api.createsend.com/oauth/token", "oauth_exchange_token_error.json")
         self.assertRaises(Exception, self.cs.exchange_token,
                           client_id, client_secret, redirect_uri, code)
-        self.assertEquals(self.cs.faker.actual_body,
+        self.assertEqual(self.cs.faker.actual_body,
                           "grant_type=authorization_code&client_id=8998879&client_secret=iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&code=invalidcode")
 
     def test_can_authenticate_by_calling_auth_with_api_key(self):
         self.cs = CreateSend(self.api_key_auth_details)
         self.cs.stub_request("systemdate.json", "systemdate.json")
         systemdate = self.cs.systemdate()
-        self.assertEquals(self.cs.headers['Authorization'], "Basic %s" % base64.b64encode(
+        self.assertEqual(self.cs.headers['Authorization'], "Basic %s" % base64.b64encode(
             ("%s:x" % self.api_key_auth_details['api_key']).encode()).decode())
-        self.assertEquals(systemdate, "2010-10-15 09:27:00")
+        self.assertEqual(systemdate, "2010-10-15 09:27:00")
 
     def test_can_authenticate_by_calling_auth_with_oauth_credentials(self):
         self.cs = CreateSend(self.oauth_auth_details)
         self.cs.stub_request("systemdate.json", "systemdate.json")
         systemdate = self.cs.systemdate()
-        self.assertEquals(self.cs.headers[
+        self.assertEqual(self.cs.headers[
                           'Authorization'], "Bearer %s" % self.oauth_auth_details['access_token'])
-        self.assertEquals(systemdate, "2010-10-15 09:27:00")
+        self.assertEqual(systemdate, "2010-10-15 09:27:00")
 
     def test_raise_error_when_authenticating_with_oauth_and_token_expired(self):
         self.cs = CreateSend(self.oauth_auth_details)
@@ -104,12 +104,12 @@ class AuthenticationTestCase(unittest.TestCase):
             "https://api.createsend.com/oauth/token", "refresh_oauth_token.json")
         new_access_token, new_expires_in, new_refresh_token = self.cs.refresh_token()
 
-        self.assertEquals(self.cs.faker.actual_body,
+        self.assertEqual(self.cs.faker.actual_body,
                           "grant_type=refresh_token&refresh_token=5S4aASP9R%2B9KsgfHB0dapTYxNA%3D%3D")
-        self.assertEquals(new_access_token, "SlAV32hkKG2e12e")
-        self.assertEquals(new_expires_in, 1209600)
-        self.assertEquals(new_refresh_token, "tGzv3JOkF0XG5Qx2TlKWIA")
-        self.assertEquals(self.cs.auth_details,
+        self.assertEqual(new_access_token, "SlAV32hkKG2e12e")
+        self.assertEqual(new_expires_in, 1209600)
+        self.assertEqual(new_refresh_token, "tGzv3JOkF0XG5Qx2TlKWIA")
+        self.assertEqual(self.cs.auth_details,
                           {'access_token': new_access_token, 'refresh_token': new_refresh_token})
 
     def test_refresh_token_error_when_refresh_token_none(self):

--- a/test/test_campaign.py
+++ b/test/test_campaign.py
@@ -1,10 +1,10 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.campaign import Campaign
 
 
-class CampaignTestCase(object):
+class CampaignTestCase:
 
     def test_create(self):
         client_id = '87y8d7qyw8d7yq8w7ydwqwd'
@@ -15,10 +15,10 @@ class CampaignTestCase(object):
                                    '7y12989e82ue98u2e', 'dh9w89q8w98wudwd989'],
                                ['y78q9w8d9w8ud9q8uw', 'djw98quw9duqw98uwd98'])
 
-        self.assertEquals(
+        self.assertEqual(
             "\"TextUrl\": \"http://example.com/campaign.txt\"" in c.faker.actual_body, True)
-        self.assertEquals(c.campaign_id, "787y87y87y87y87y87y8712341234")
-        self.assertEquals(campaign_id, "787y87y87y87y87y87y8712341234")
+        self.assertEqual(c.campaign_id, "787y87y87y87y87y87y8712341234")
+        self.assertEqual(campaign_id, "787y87y87y87y87y87y8712341234")
 
     def test_create_with_none_text_url(self):
         client_id = '87y8d7qyw8d7yq8w7ydwqwd'
@@ -29,9 +29,9 @@ class CampaignTestCase(object):
                                    '7y12989e82ue98u2e', 'dh9w89q8w98wudwd989'],
                                ['y78q9w8d9w8ud9q8uw', 'djw98quw9duqw98uwd98'])
 
-        self.assertEquals("\"TextUrl\": null" in c.faker.actual_body, True)
-        self.assertEquals(c.campaign_id, "787y87y87y87y87y87y8712341234")
-        self.assertEquals(campaign_id, "787y87y87y87y87y87y8712341234")
+        self.assertEqual("\"TextUrl\": null" in c.faker.actual_body, True)
+        self.assertEqual(c.campaign_id, "787y87y87y87y87y87y8712341234")
+        self.assertEqual(campaign_id, "787y87y87y87y87y87y8712341234")
 
     def test_create_from_template(self):
         template_content = {
@@ -112,8 +112,8 @@ class CampaignTestCase(object):
                                              ['7y12989e82ue98u2e', 'dh9w89q8w98wudwd989'], [
                                                  'y78q9w8d9w8ud9q8uw', 'djw98quw9duqw98uwd98'],
                                              "7j8uw98udowy12989e8298u2e", template_content)
-        self.assertEquals(c.campaign_id, "787y87y87y87y87y87y8712341234")
-        self.assertEquals(campaign_id, "787y87y87y87y87y87y8712341234")
+        self.assertEqual(c.campaign_id, "787y87y87y87y87y87y8712341234")
+        self.assertEqual(campaign_id, "787y87y87y87y87y87y8712341234")
 
     def test_send_preview_with_single_recipient(self):
         self.campaign.stub_request(
@@ -145,23 +145,23 @@ class CampaignTestCase(object):
         self.campaign.stub_request(
             "campaigns/%s/summary.json" % self.campaign_id, "campaign_summary.json")
         summary = self.campaign.summary()
-        self.assertEquals(summary.Name, "Last Campaign")
-        self.assertEquals(summary.Recipients, 5)
-        self.assertEquals(summary.TotalOpened, 10)
-        self.assertEquals(summary.Clicks, 0)
-        self.assertEquals(summary.Unsubscribed, 0)
-        self.assertEquals(summary.Bounced, 0)
-        self.assertEquals(summary.UniqueOpened, 5)
-        self.assertEquals(summary.Mentions, 23)
-        self.assertEquals(summary.Forwards, 11)
-        self.assertEquals(summary.Likes, 32)
-        self.assertEquals(summary.WebVersionURL,
+        self.assertEqual(summary.Name, "Last Campaign")
+        self.assertEqual(summary.Recipients, 5)
+        self.assertEqual(summary.TotalOpened, 10)
+        self.assertEqual(summary.Clicks, 0)
+        self.assertEqual(summary.Unsubscribed, 0)
+        self.assertEqual(summary.Bounced, 0)
+        self.assertEqual(summary.UniqueOpened, 5)
+        self.assertEqual(summary.Mentions, 23)
+        self.assertEqual(summary.Forwards, 11)
+        self.assertEqual(summary.Likes, 32)
+        self.assertEqual(summary.WebVersionURL,
                           "http://createsend.com/t/r-3A433FC72FFE3B8B")
-        self.assertEquals(summary.WebVersionTextURL,
+        self.assertEqual(summary.WebVersionTextURL,
                           "http://createsend.com/t/r-3A433FC72FFE3B8B/t")
-        self.assertEquals(
+        self.assertEqual(
             summary.WorldviewURL, "http://client.createsend.com/reports/wv/r/3A433FC72FFE3B8B")
-        self.assertEquals(summary.SpamComplaints, 23)
+        self.assertEqual(summary.SpamComplaints, 23)
 
     def test_email_client_usage(self):
         self.campaign.stub_request(
@@ -177,32 +177,32 @@ class CampaignTestCase(object):
         self.campaign.stub_request("campaigns/%s/listsandsegments.json" %
                                    self.campaign_id, "campaign_listsandsegments.json")
         ls = self.campaign.lists_and_segments()
-        self.assertEquals(len(ls.Lists), 1)
-        self.assertEquals(len(ls.Segments), 1)
-        self.assertEquals(ls.Lists[0].Name, "List One")
-        self.assertEquals(ls.Lists[0].ListID,
+        self.assertEqual(len(ls.Lists), 1)
+        self.assertEqual(len(ls.Segments), 1)
+        self.assertEqual(ls.Lists[0].Name, "List One")
+        self.assertEqual(ls.Lists[0].ListID,
                           "a58ee1d3039b8bec838e6d1482a8a965")
-        self.assertEquals(ls.Segments[0].Title, "Segment for campaign")
-        self.assertEquals(ls.Segments[0].ListID,
+        self.assertEqual(ls.Segments[0].Title, "Segment for campaign")
+        self.assertEqual(ls.Segments[0].ListID,
                           "2bea949d0bf96148c3e6a209d2e82060")
-        self.assertEquals(ls.Segments[0].SegmentID,
+        self.assertEqual(ls.Segments[0].SegmentID,
                           "dba84a225d5ce3d19105d7257baac46f")
 
     def test_recipients(self):
         self.campaign.stub_request("campaigns/%s/recipients.json?orderfield=email&page=1&pagesize=20&orderdirection=asc" %
                                    self.campaign_id, "campaign_recipients.json")
         res = self.campaign.recipients(page=1, page_size=20)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 20)
-        self.assertEquals(res.RecordsOnThisPage, 20)
-        self.assertEquals(res.TotalNumberOfRecords, 2200)
-        self.assertEquals(res.NumberOfPages, 110)
-        self.assertEquals(len(res.Results), 20)
-        self.assertEquals(res.Results[0].EmailAddress,
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 20)
+        self.assertEqual(res.RecordsOnThisPage, 20)
+        self.assertEqual(res.TotalNumberOfRecords, 2200)
+        self.assertEqual(res.NumberOfPages, 110)
+        self.assertEqual(len(res.Results), 20)
+        self.assertEqual(res.Results[0].EmailAddress,
                           "subs+6g76t7t0@example.com")
-        self.assertEquals(res.Results[0].ListID,
+        self.assertEqual(res.Results[0].ListID,
                           "a994a3caf1328a16af9a69a730eaa706")
 
     def test_opens(self):
@@ -210,115 +210,115 @@ class CampaignTestCase(object):
         self.campaign.stub_request("campaigns/%s/opens.json?date=%s&orderfield=date&page=1&pagesize=1000&orderdirection=asc" %
                                    (self.campaign_id, quote(min_date, '')), "campaign_opens.json")
         opens = self.campaign.opens(min_date)
-        self.assertEquals(len(opens.Results), 5)
-        self.assertEquals(
+        self.assertEqual(len(opens.Results), 5)
+        self.assertEqual(
             opens.Results[0].EmailAddress, "subs+6576576576@example.com")
-        self.assertEquals(opens.Results[0].ListID,
+        self.assertEqual(opens.Results[0].ListID,
                           "512a3bc577a58fdf689c654329b50fa0")
-        self.assertEquals(opens.Results[0].Date, "2010-10-11 08:29:00")
-        self.assertEquals(opens.Results[0].IPAddress, "192.168.126.87")
-        self.assertEquals(opens.Results[0].Latitude, -33.8683)
-        self.assertEquals(opens.Results[0].Longitude, 151.2086)
-        self.assertEquals(opens.Results[0].City, "Sydney")
-        self.assertEquals(opens.Results[0].Region, "New South Wales")
-        self.assertEquals(opens.Results[0].CountryCode, "AU")
-        self.assertEquals(opens.Results[0].CountryName, "Australia")
-        self.assertEquals(opens.ResultsOrderedBy, "date")
-        self.assertEquals(opens.OrderDirection, "asc")
-        self.assertEquals(opens.PageNumber, 1)
-        self.assertEquals(opens.PageSize, 1000)
-        self.assertEquals(opens.RecordsOnThisPage, 5)
-        self.assertEquals(opens.TotalNumberOfRecords, 5)
-        self.assertEquals(opens.NumberOfPages, 1)
+        self.assertEqual(opens.Results[0].Date, "2010-10-11 08:29:00")
+        self.assertEqual(opens.Results[0].IPAddress, "192.168.126.87")
+        self.assertEqual(opens.Results[0].Latitude, -33.8683)
+        self.assertEqual(opens.Results[0].Longitude, 151.2086)
+        self.assertEqual(opens.Results[0].City, "Sydney")
+        self.assertEqual(opens.Results[0].Region, "New South Wales")
+        self.assertEqual(opens.Results[0].CountryCode, "AU")
+        self.assertEqual(opens.Results[0].CountryName, "Australia")
+        self.assertEqual(opens.ResultsOrderedBy, "date")
+        self.assertEqual(opens.OrderDirection, "asc")
+        self.assertEqual(opens.PageNumber, 1)
+        self.assertEqual(opens.PageSize, 1000)
+        self.assertEqual(opens.RecordsOnThisPage, 5)
+        self.assertEqual(opens.TotalNumberOfRecords, 5)
+        self.assertEqual(opens.NumberOfPages, 1)
 
     def test_clicks(self):
         min_date = "2010-01-01"
         self.campaign.stub_request("campaigns/%s/clicks.json?date=%s&orderfield=date&page=1&pagesize=1000&orderdirection=asc" %
                                    (self.campaign_id, quote(min_date, '')), "campaign_clicks.json")
         clicks = self.campaign.clicks(min_date)
-        self.assertEquals(len(clicks.Results), 3)
-        self.assertEquals(
+        self.assertEqual(len(clicks.Results), 3)
+        self.assertEqual(
             clicks.Results[0].EmailAddress, "subs+6576576576@example.com")
-        self.assertEquals(
+        self.assertEqual(
             clicks.Results[0].URL, "http://video.google.com.au/?hl=en&tab=wv")
-        self.assertEquals(
+        self.assertEqual(
             clicks.Results[0].ListID, "512a3bc577a58fdf689c654329b50fa0")
-        self.assertEquals(clicks.Results[0].Date, "2010-10-11 08:29:00")
-        self.assertEquals(clicks.Results[0].IPAddress, "192.168.126.87")
-        self.assertEquals(clicks.Results[0].Latitude, -33.8683)
-        self.assertEquals(clicks.Results[0].Longitude, 151.2086)
-        self.assertEquals(clicks.Results[0].City, "Sydney")
-        self.assertEquals(clicks.Results[0].Region, "New South Wales")
-        self.assertEquals(clicks.Results[0].CountryCode, "AU")
-        self.assertEquals(clicks.Results[0].CountryName, "Australia")
-        self.assertEquals(clicks.ResultsOrderedBy, "date")
-        self.assertEquals(clicks.OrderDirection, "asc")
-        self.assertEquals(clicks.PageNumber, 1)
-        self.assertEquals(clicks.PageSize, 1000)
-        self.assertEquals(clicks.RecordsOnThisPage, 3)
-        self.assertEquals(clicks.TotalNumberOfRecords, 3)
-        self.assertEquals(clicks.NumberOfPages, 1)
+        self.assertEqual(clicks.Results[0].Date, "2010-10-11 08:29:00")
+        self.assertEqual(clicks.Results[0].IPAddress, "192.168.126.87")
+        self.assertEqual(clicks.Results[0].Latitude, -33.8683)
+        self.assertEqual(clicks.Results[0].Longitude, 151.2086)
+        self.assertEqual(clicks.Results[0].City, "Sydney")
+        self.assertEqual(clicks.Results[0].Region, "New South Wales")
+        self.assertEqual(clicks.Results[0].CountryCode, "AU")
+        self.assertEqual(clicks.Results[0].CountryName, "Australia")
+        self.assertEqual(clicks.ResultsOrderedBy, "date")
+        self.assertEqual(clicks.OrderDirection, "asc")
+        self.assertEqual(clicks.PageNumber, 1)
+        self.assertEqual(clicks.PageSize, 1000)
+        self.assertEqual(clicks.RecordsOnThisPage, 3)
+        self.assertEqual(clicks.TotalNumberOfRecords, 3)
+        self.assertEqual(clicks.NumberOfPages, 1)
 
     def test_unsubscribes(self):
         min_date = "2010-01-01"
         self.campaign.stub_request("campaigns/%s/unsubscribes.json?date=%s&orderfield=date&page=1&pagesize=1000&orderdirection=asc" %
                                    (self.campaign_id, quote(min_date, '')), "campaign_unsubscribes.json")
         unsubscribes = self.campaign.unsubscribes(min_date)
-        self.assertEquals(len(unsubscribes.Results), 1)
-        self.assertEquals(unsubscribes.Results[
+        self.assertEqual(len(unsubscribes.Results), 1)
+        self.assertEqual(unsubscribes.Results[
                           0].EmailAddress, "subs+6576576576@example.com")
-        self.assertEquals(unsubscribes.Results[
+        self.assertEqual(unsubscribes.Results[
                           0].ListID, "512a3bc577a58fdf689c654329b50fa0")
-        self.assertEquals(unsubscribes.Results[0].Date, "2010-10-11 08:29:00")
-        self.assertEquals(unsubscribes.Results[0].IPAddress, "192.168.126.87")
-        self.assertEquals(unsubscribes.ResultsOrderedBy, "date")
-        self.assertEquals(unsubscribes.OrderDirection, "asc")
-        self.assertEquals(unsubscribes.PageNumber, 1)
-        self.assertEquals(unsubscribes.PageSize, 1000)
-        self.assertEquals(unsubscribes.RecordsOnThisPage, 1)
-        self.assertEquals(unsubscribes.TotalNumberOfRecords, 1)
-        self.assertEquals(unsubscribes.NumberOfPages, 1)
+        self.assertEqual(unsubscribes.Results[0].Date, "2010-10-11 08:29:00")
+        self.assertEqual(unsubscribes.Results[0].IPAddress, "192.168.126.87")
+        self.assertEqual(unsubscribes.ResultsOrderedBy, "date")
+        self.assertEqual(unsubscribes.OrderDirection, "asc")
+        self.assertEqual(unsubscribes.PageNumber, 1)
+        self.assertEqual(unsubscribes.PageSize, 1000)
+        self.assertEqual(unsubscribes.RecordsOnThisPage, 1)
+        self.assertEqual(unsubscribes.TotalNumberOfRecords, 1)
+        self.assertEqual(unsubscribes.NumberOfPages, 1)
 
     def test_spam(self):
         min_date = "2010-01-01"
         self.campaign.stub_request("campaigns/%s/spam.json?date=%s&orderfield=date&page=1&pagesize=1000&orderdirection=asc" %
                                    (self.campaign_id, quote(min_date, '')), "campaign_spam.json")
         spam = self.campaign.spam(min_date)
-        self.assertEquals(len(spam.Results), 1)
-        self.assertEquals(
+        self.assertEqual(len(spam.Results), 1)
+        self.assertEqual(
             spam.Results[0].EmailAddress, "subs+6576576576@example.com")
-        self.assertEquals(spam.Results[0].ListID,
+        self.assertEqual(spam.Results[0].ListID,
                           "512a3bc577a58fdf689c654329b50fa0")
-        self.assertEquals(spam.Results[0].Date, "2010-10-11 08:29:00")
-        self.assertEquals(spam.ResultsOrderedBy, "date")
-        self.assertEquals(spam.OrderDirection, "asc")
-        self.assertEquals(spam.PageNumber, 1)
-        self.assertEquals(spam.PageSize, 1000)
-        self.assertEquals(spam.RecordsOnThisPage, 1)
-        self.assertEquals(spam.TotalNumberOfRecords, 1)
-        self.assertEquals(spam.NumberOfPages, 1)
+        self.assertEqual(spam.Results[0].Date, "2010-10-11 08:29:00")
+        self.assertEqual(spam.ResultsOrderedBy, "date")
+        self.assertEqual(spam.OrderDirection, "asc")
+        self.assertEqual(spam.PageNumber, 1)
+        self.assertEqual(spam.PageSize, 1000)
+        self.assertEqual(spam.RecordsOnThisPage, 1)
+        self.assertEqual(spam.TotalNumberOfRecords, 1)
+        self.assertEqual(spam.NumberOfPages, 1)
 
     def test_bounces(self):
         min_date = "2010-01-01"
         self.campaign.stub_request("campaigns/%s/bounces.json?date=%s&orderfield=date&page=1&pagesize=1000&orderdirection=asc" %
                                    (self.campaign_id, quote(min_date, '')), "campaign_bounces.json")
         bounces = self.campaign.bounces(min_date)
-        self.assertEquals(len(bounces.Results), 2)
-        self.assertEquals(
+        self.assertEqual(len(bounces.Results), 2)
+        self.assertEqual(
             bounces.Results[0].EmailAddress, "asdf@softbouncemyemail.com")
-        self.assertEquals(
+        self.assertEqual(
             bounces.Results[0].ListID, "654523a5855b4a440bae3fb295641546")
-        self.assertEquals(bounces.Results[0].BounceType, "Soft")
-        self.assertEquals(bounces.Results[0].Date, "2010-07-02 16:46:00")
-        self.assertEquals(
+        self.assertEqual(bounces.Results[0].BounceType, "Soft")
+        self.assertEqual(bounces.Results[0].Date, "2010-07-02 16:46:00")
+        self.assertEqual(
             bounces.Results[0].Reason, "Bounce - But No Email Address Returned ")
-        self.assertEquals(bounces.ResultsOrderedBy, "date")
-        self.assertEquals(bounces.OrderDirection, "asc")
-        self.assertEquals(bounces.PageNumber, 1)
-        self.assertEquals(bounces.PageSize, 1000)
-        self.assertEquals(bounces.RecordsOnThisPage, 2)
-        self.assertEquals(bounces.TotalNumberOfRecords, 2)
-        self.assertEquals(bounces.NumberOfPages, 1)
+        self.assertEqual(bounces.ResultsOrderedBy, "date")
+        self.assertEqual(bounces.OrderDirection, "asc")
+        self.assertEqual(bounces.PageNumber, 1)
+        self.assertEqual(bounces.PageSize, 1000)
+        self.assertEqual(bounces.RecordsOnThisPage, 2)
+        self.assertEqual(bounces.TotalNumberOfRecords, 2)
+        self.assertEqual(bounces.NumberOfPages, 1)
 
 
 class OAuthCampaignTestCase(unittest.TestCase, CampaignTestCase):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,157 +1,157 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.client import Client
 
 
-class ClientTestCase(object):
+class ClientTestCase:
 
     def test_create(self):
         c = Client()
         c.stub_request("clients.json", "create_client.json")
         client_id = c.create(
             "Client Company Name", "(GMT+10:00) Canberra, Melbourne, Sydney", "Australia")
-        self.assertEquals("32a381c49a2df99f1d0c6f3c112352b9", client_id)
-        self.assertEquals("32a381c49a2df99f1d0c6f3c112352b9", c.client_id)
+        self.assertEqual("32a381c49a2df99f1d0c6f3c112352b9", client_id)
+        self.assertEqual("32a381c49a2df99f1d0c6f3c112352b9", c.client_id)
 
     def test_details(self):
         self.cl.stub_request("clients/%s.json" %
                              self.cl.client_id, "client_details.json")
         cl = self.cl.details()
-        self.assertEquals(
+        self.assertEqual(
             cl.ApiKey, "639d8cc27198202f5fe6037a8b17a29a59984b86d3289bc9")
-        self.assertEquals(cl.BasicDetails.ClientID,
+        self.assertEqual(cl.BasicDetails.ClientID,
                           "4a397ccaaa55eb4e6aa1221e1e2d7122")
-        self.assertEquals(cl.BasicDetails.ContactName, "Client One (contact)")
-        self.assertEquals(cl.AccessDetails.Username, "clientone")
-        self.assertEquals(cl.AccessDetails.AccessLevel, 23)
-        self.assertEquals(cl.BillingDetails.Credits, 500)
+        self.assertEqual(cl.BasicDetails.ContactName, "Client One (contact)")
+        self.assertEqual(cl.AccessDetails.Username, "clientone")
+        self.assertEqual(cl.AccessDetails.AccessLevel, 23)
+        self.assertEqual(cl.BillingDetails.Credits, 500)
 
     def test_campaigns(self):
         self.cl.stub_request("clients/%s/campaigns.json?sentfromdate=&senttodate=&page=1&tags=&pagesize=1000&orderdirection=desc" %
                              self.cl.client_id, "campaigns.json")
         sentCampaigns = self.cl.campaigns()
         campaigns = sentCampaigns.Results
-        self.assertEquals(len(campaigns), 2)
-        self.assertEquals(campaigns[0].CampaignID,
+        self.assertEqual(len(campaigns), 2)
+        self.assertEqual(campaigns[0].CampaignID,
                           'fc0ce7105baeaf97f47c99be31d02a91')
-        self.assertEquals(campaigns[0].WebVersionURL,
+        self.assertEqual(campaigns[0].WebVersionURL,
                           'http://createsend.com/t/r-765E86829575EE2C')
-        self.assertEquals(campaigns[0].WebVersionTextURL,
+        self.assertEqual(campaigns[0].WebVersionTextURL,
                           'http://createsend.com/t/r-765E86829575EE2C/t')
-        self.assertEquals(campaigns[0].Subject, 'Campaign One')
-        self.assertEquals(campaigns[0].Name, 'Campaign One')
-        self.assertEquals(campaigns[0].SentDate, '2010-10-12 12:58:00')
-        self.assertEquals(campaigns[0].TotalRecipients, 2245)
-        self.assertEquals(campaigns[0].FromName, 'My Name')
-        self.assertEquals(campaigns[0].FromEmail, 'myemail@example.com')
-        self.assertEquals(campaigns[0].ReplyTo, 'myemail@example.com')
-        self.assertEquals(campaigns[0].Tags, ["Tag1", "Tag2"])
-        self.assertEquals(sentCampaigns.ResultsOrderedBy, "SentDate")
-        self.assertEquals(sentCampaigns.OrderDirection, "desc")
-        self.assertEquals(sentCampaigns.PageNumber, 1)
-        self.assertEquals(sentCampaigns.PageSize, 2)
-        self.assertEquals(sentCampaigns.RecordsOnThisPage, 2)
-        self.assertEquals(sentCampaigns.TotalNumberOfRecords, 49)
-        self.assertEquals(sentCampaigns.NumberOfPages, 25)
+        self.assertEqual(campaigns[0].Subject, 'Campaign One')
+        self.assertEqual(campaigns[0].Name, 'Campaign One')
+        self.assertEqual(campaigns[0].SentDate, '2010-10-12 12:58:00')
+        self.assertEqual(campaigns[0].TotalRecipients, 2245)
+        self.assertEqual(campaigns[0].FromName, 'My Name')
+        self.assertEqual(campaigns[0].FromEmail, 'myemail@example.com')
+        self.assertEqual(campaigns[0].ReplyTo, 'myemail@example.com')
+        self.assertEqual(campaigns[0].Tags, ["Tag1", "Tag2"])
+        self.assertEqual(sentCampaigns.ResultsOrderedBy, "SentDate")
+        self.assertEqual(sentCampaigns.OrderDirection, "desc")
+        self.assertEqual(sentCampaigns.PageNumber, 1)
+        self.assertEqual(sentCampaigns.PageSize, 2)
+        self.assertEqual(sentCampaigns.RecordsOnThisPage, 2)
+        self.assertEqual(sentCampaigns.TotalNumberOfRecords, 49)
+        self.assertEqual(sentCampaigns.NumberOfPages, 25)
 
     def test_scheduled(self):
         self.cl.stub_request("clients/%s/scheduled.json" %
                              self.cl.client_id, "scheduled_campaigns.json")
         campaigns = self.cl.scheduled()
-        self.assertEquals(len(campaigns), 2)
-        self.assertEquals(campaigns[0].DateScheduled, "2011-05-25 10:40:00")
-        self.assertEquals(campaigns[0].ScheduledTimeZone,
+        self.assertEqual(len(campaigns), 2)
+        self.assertEqual(campaigns[0].DateScheduled, "2011-05-25 10:40:00")
+        self.assertEqual(campaigns[0].ScheduledTimeZone,
                           "(GMT+10:00) Canberra, Melbourne, Sydney")
-        self.assertEquals(campaigns[0].CampaignID,
+        self.assertEqual(campaigns[0].CampaignID,
                           "827dbbd2161ea9989fa11ad562c66937")
-        self.assertEquals(campaigns[0].Name, "Magic Issue One")
-        self.assertEquals(campaigns[0].Subject, "Magic Issue One")
-        self.assertEquals(campaigns[0].DateCreated, "2011-05-24 10:37:00")
-        self.assertEquals(campaigns[0].PreviewURL,
+        self.assertEqual(campaigns[0].Name, "Magic Issue One")
+        self.assertEqual(campaigns[0].Subject, "Magic Issue One")
+        self.assertEqual(campaigns[0].DateCreated, "2011-05-24 10:37:00")
+        self.assertEqual(campaigns[0].PreviewURL,
                           "http://createsend.com/t/r-DD543521A87C9B8B")
-        self.assertEquals(campaigns[0].PreviewTextURL,
+        self.assertEqual(campaigns[0].PreviewTextURL,
                           "http://createsend.com/t/r-DD543521A87C9B8B/t")
-        self.assertEquals(campaigns[0].FromName, 'My Name')
-        self.assertEquals(campaigns[0].FromEmail, 'myemail@example.com')
-        self.assertEquals(campaigns[0].ReplyTo, 'myemail@example.com')
-        self.assertEquals(campaigns[0].Tags, [])
+        self.assertEqual(campaigns[0].FromName, 'My Name')
+        self.assertEqual(campaigns[0].FromEmail, 'myemail@example.com')
+        self.assertEqual(campaigns[0].ReplyTo, 'myemail@example.com')
+        self.assertEqual(campaigns[0].Tags, [])
 
     def test_drafts(self):
         self.cl.stub_request("clients/%s/drafts.json" %
                              self.cl.client_id, "drafts.json")
         drafts = self.cl.drafts()
-        self.assertEquals(len(drafts), 2)
-        self.assertEquals(drafts[0].CampaignID,
+        self.assertEqual(len(drafts), 2)
+        self.assertEqual(drafts[0].CampaignID,
                           '7c7424792065d92627139208c8c01db1')
-        self.assertEquals(drafts[0].Name, 'Draft One')
-        self.assertEquals(drafts[0].Subject, 'Draft One')
-        self.assertEquals(drafts[0].DateCreated, '2010-08-19 16:08:00')
-        self.assertEquals(drafts[0].PreviewURL,
+        self.assertEqual(drafts[0].Name, 'Draft One')
+        self.assertEqual(drafts[0].Subject, 'Draft One')
+        self.assertEqual(drafts[0].DateCreated, '2010-08-19 16:08:00')
+        self.assertEqual(drafts[0].PreviewURL,
                           'http://createsend.com/t/r-E97A7BB2E6983DA1')
-        self.assertEquals(drafts[0].PreviewTextURL,
+        self.assertEqual(drafts[0].PreviewTextURL,
                           'http://createsend.com/t/r-E97A7BB2E6983DA1/t')
-        self.assertEquals(drafts[0].FromName, 'My Name')
-        self.assertEquals(drafts[0].FromEmail, 'myemail@example.com')
-        self.assertEquals(drafts[0].ReplyTo, 'myemail@example.com')
-        self.assertEquals(drafts[0].Tags, ["Tags5"])
+        self.assertEqual(drafts[0].FromName, 'My Name')
+        self.assertEqual(drafts[0].FromEmail, 'myemail@example.com')
+        self.assertEqual(drafts[0].ReplyTo, 'myemail@example.com')
+        self.assertEqual(drafts[0].Tags, ["Tags5"])
     
     def test_tags(self):
         self.cl.stub_request("clients/%s/tags.json" %
                              self.cl.client_id, "tags.json")
         tags = self.cl.tags()
-        self.assertEquals(len(tags), 2)
-        self.assertEquals(tags[0].Name, 'Happy')
-        self.assertEquals(tags[0].NumberOfCampaigns, 3)
-        self.assertEquals(tags[1].Name, 'Sad')
-        self.assertEquals(tags[1].NumberOfCampaigns, 1)
+        self.assertEqual(len(tags), 2)
+        self.assertEqual(tags[0].Name, 'Happy')
+        self.assertEqual(tags[0].NumberOfCampaigns, 3)
+        self.assertEqual(tags[1].Name, 'Sad')
+        self.assertEqual(tags[1].NumberOfCampaigns, 1)
 
     def test_lists(self):
         self.cl.stub_request("clients/%s/lists.json" %
                              self.cl.client_id, "lists.json")
         lists = self.cl.lists()
-        self.assertEquals(len(lists), 2)
-        self.assertEquals(lists[0].ListID, 'a58ee1d3039b8bec838e6d1482a8a965')
-        self.assertEquals(lists[0].Name, 'List One')
+        self.assertEqual(len(lists), 2)
+        self.assertEqual(lists[0].ListID, 'a58ee1d3039b8bec838e6d1482a8a965')
+        self.assertEqual(lists[0].Name, 'List One')
 
     def test_lists_for_email(self):
         email = "valid@example.com"
         self.cl.stub_request("clients/%s/listsforemail.json?email=%s" %
                              (self.cl.client_id, quote(email)), "listsforemail.json")
         lists = self.cl.lists_for_email(email)
-        self.assertEquals(len(lists), 2)
-        self.assertEquals(lists[0].ListID, 'ab4a2b57c7c8f1ba62f898a1af1a575b')
-        self.assertEquals(lists[0].ListName, 'List Number One')
-        self.assertEquals(lists[0].SubscriberState, 'Active')
-        self.assertEquals(lists[0].DateSubscriberAdded, '2012-08-20 22:32:00')
+        self.assertEqual(len(lists), 2)
+        self.assertEqual(lists[0].ListID, 'ab4a2b57c7c8f1ba62f898a1af1a575b')
+        self.assertEqual(lists[0].ListName, 'List Number One')
+        self.assertEqual(lists[0].SubscriberState, 'Active')
+        self.assertEqual(lists[0].DateSubscriberAdded, '2012-08-20 22:32:00')
 
     def test_segments(self):
         self.cl.stub_request("clients/%s/segments.json" %
                              self.cl.client_id, "segments.json")
         segments = self.cl.segments()
-        self.assertEquals(len(segments), 2)
-        self.assertEquals(segments[0].ListID,
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[0].ListID,
                           'a58ee1d3039b8bec838e6d1482a8a965')
-        self.assertEquals(segments[0].SegmentID,
+        self.assertEqual(segments[0].SegmentID,
                           '46aa5e01fd43381863d4e42cf277d3a9')
-        self.assertEquals(segments[0].Title, 'Segment One')
+        self.assertEqual(segments[0].Title, 'Segment One')
 
     def test_suppressionlist(self):
         self.cl.stub_request("clients/%s/suppressionlist.json?orderfield=email&page=1&pagesize=1000&orderdirection=asc" %
                              self.cl.client_id, "suppressionlist.json")
         res = self.cl.suppressionlist()
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 5)
-        self.assertEquals(res.TotalNumberOfRecords, 5)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 5)
-        self.assertEquals(res.Results[0].SuppressionReason, "Unsubscribed")
-        self.assertEquals(res.Results[0].EmailAddress, "example+1@example.com")
-        self.assertEquals(res.Results[0].Date, "2010-10-26 10:55:31")
-        self.assertEquals(res.Results[0].State, "Suppressed")
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 5)
+        self.assertEqual(res.TotalNumberOfRecords, 5)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 5)
+        self.assertEqual(res.Results[0].SuppressionReason, "Unsubscribed")
+        self.assertEqual(res.Results[0].EmailAddress, "example+1@example.com")
+        self.assertEqual(res.Results[0].Date, "2010-10-26 10:55:31")
+        self.assertEqual(res.Results[0].State, "Suppressed")
 
     def test_suppress_with_single_email(self):
         self.cl.stub_request("clients/%s/suppress.json" %
@@ -173,10 +173,10 @@ class ClientTestCase(object):
         self.cl.stub_request("clients/%s/templates.json" %
                              self.cl.client_id, "templates.json")
         templates = self.cl.templates()
-        self.assertEquals(len(templates), 2)
-        self.assertEquals(templates[0].TemplateID,
+        self.assertEqual(len(templates), 2)
+        self.assertEqual(templates[0].TemplateID,
                           '5cac213cf061dd4e008de5a82b7a3621')
-        self.assertEquals(templates[0].Name, 'Template One')
+        self.assertEqual(templates[0].Name, 'Template One')
 
     def test_set_basics(self):
         self.cl.stub_request("clients/%s/setbasics.json" %
@@ -208,30 +208,30 @@ class ClientTestCase(object):
         self.cl.stub_request("clients/%s/credits.json" %
                              self.cl.client_id, "transfer_credits.json")
         result = self.cl.transfer_credits(200, False)
-        self.assertEquals(result.AccountCredits, 800)
-        self.assertEquals(result.ClientCredits, 200)
+        self.assertEqual(result.AccountCredits, 800)
+        self.assertEqual(result.ClientCredits, 200)
 
     def test_people(self):
         self.cl.stub_request("clients/%s/people.json" %
                              self.cl.client_id, "people.json")
         people = self.cl.people()
-        self.assertEquals(2, len(people))
-        self.assertEquals('person1@blackhole.com', people[0].EmailAddress)
-        self.assertEquals('Person One', people[0].Name)
-        self.assertEquals('Active', people[0].Status)
+        self.assertEqual(2, len(people))
+        self.assertEqual('person1@blackhole.com', people[0].EmailAddress)
+        self.assertEqual('Person One', people[0].Name)
+        self.assertEqual('Active', people[0].Status)
 
     def test_get_primary_contact(self):
         self.cl.stub_request("clients/%s/primarycontact.json" %
                              self.cl.client_id, "client_get_primary_contact.json")
         primary_contact = self.cl.get_primary_contact()
-        self.assertEquals('person@blackhole.com', primary_contact.EmailAddress)
+        self.assertEqual('person@blackhole.com', primary_contact.EmailAddress)
 
     def test_set_primary_contact(self):
         email = 'person@blackhole.com'
         self.cl.stub_request("clients/%s/primarycontact.json?email=%s" %
                              (self.cl.client_id, quote(email, '')), 'client_set_primary_contact.json')
         result = self.cl.set_primary_contact(email)
-        self.assertEquals(email, result.EmailAddress)
+        self.assertEqual(email, result.EmailAddress)
 
     def test_delete(self):
         self.cl.stub_request("clients/%s.json" % self.cl.client_id, None)

--- a/test/test_createsend.py
+++ b/test/test_createsend.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.createsend import (
@@ -13,75 +13,75 @@ from createsend.client import Client
 from createsend.template import Template
 
 
-class CreateSendTestCase(object):
+class CreateSendTestCase:
     """CreateSend tests to be run in the context of both using an API key 
     and using OAuth."""
 
     def test_that_default_user_agent_is_set(self):
         self.cs.stub_request("clients.json", "clients.json")
         cl = self.cs.clients()
-        self.assertEquals(
+        self.assertEqual(
             self.cs.headers['User-Agent'], CreateSend.default_user_agent)
-        self.assertEquals(2, len(cl))
+        self.assertEqual(2, len(cl))
 
     def test_that_custom_user_agent_can_be_set(self):
         CreateSend.user_agent = "custom user agent"
         self.cs.stub_request("clients.json", "clients.json")
         cl = self.cs.clients()
-        self.assertEquals(self.cs.headers['User-Agent'], "custom user agent")
-        self.assertEquals(2, len(cl))
+        self.assertEqual(self.cs.headers['User-Agent'], "custom user agent")
+        self.assertEqual(2, len(cl))
         CreateSend.user_agent = CreateSend.default_user_agent
 
     def test_clients(self):
         self.cs.stub_request("clients.json", "clients.json")
         cl = self.cs.clients()
-        self.assertEquals(2, len(cl))
-        self.assertEquals("4a397ccaaa55eb4e6aa1221e1e2d7122", cl[0].ClientID)
-        self.assertEquals("Client One", cl[0].Name)
+        self.assertEqual(2, len(cl))
+        self.assertEqual("4a397ccaaa55eb4e6aa1221e1e2d7122", cl[0].ClientID)
+        self.assertEqual("Client One", cl[0].Name)
 
     def test_billing_details(self):
         self.cs.stub_request("billingdetails.json", "billingdetails.json")
         bd = self.cs.billing_details()
-        self.assertEquals(3021, bd.Credits)
+        self.assertEqual(3021, bd.Credits)
 
     def test_countries(self):
         self.cs.stub_request("countries.json", "countries.json")
         countries = self.cs.countries()
-        self.assertEquals(245, len(countries))
-        self.assertEquals("Australia", countries[11])
+        self.assertEqual(245, len(countries))
+        self.assertEqual("Australia", countries[11])
 
     def test_systemdate(self):
         self.cs.stub_request("systemdate.json", "systemdate.json")
         systemdate = self.cs.systemdate()
-        self.assertEquals(systemdate, "2010-10-15 09:27:00")
+        self.assertEqual(systemdate, "2010-10-15 09:27:00")
 
     def test_timezones(self):
         self.cs.stub_request("timezones.json", "timezones.json")
         timezones = self.cs.timezones()
-        self.assertEquals(97, len(timezones))
-        self.assertEquals("(GMT+12:00) Fiji", timezones[61])
+        self.assertEqual(97, len(timezones))
+        self.assertEqual("(GMT+12:00) Fiji", timezones[61])
 
     def test_administrators(self):
         self.cs.stub_request("admins.json", "administrators.json")
         administrators = self.cs.administrators()
-        self.assertEquals(2, len(administrators))
-        self.assertEquals('admin1@blackhole.com',
+        self.assertEqual(2, len(administrators))
+        self.assertEqual('admin1@blackhole.com',
                           administrators[0].EmailAddress)
-        self.assertEquals('Admin One', administrators[0].Name)
-        self.assertEquals('Active', administrators[0].Status)
+        self.assertEqual('Admin One', administrators[0].Name)
+        self.assertEqual('Active', administrators[0].Status)
 
     def test_get_primary_contact(self):
         self.cs.stub_request("primarycontact.json",
                              "admin_get_primary_contact.json")
         primary_contact = self.cs.get_primary_contact()
-        self.assertEquals('admin@blackhole.com', primary_contact.EmailAddress)
+        self.assertEqual('admin@blackhole.com', primary_contact.EmailAddress)
 
     def test_set_primary_contact(self):
         email = 'admin@blackhole.com'
         self.cs.stub_request('primarycontact.json?email=%s' %
                              quote(email, ''), 'admin_set_primary_contact.json')
         result = self.cs.set_primary_contact(email)
-        self.assertEquals(email, result.EmailAddress)
+        self.assertEqual(email, result.EmailAddress)
 
     def test_external_session_url(self):
         email = "exammple@example.com"
@@ -92,7 +92,7 @@ class CreateSendTestCase(object):
         self.cs.stub_request('externalsession.json', 'external_session.json')
         result = self.cs.external_session_url(
             email, chrome, url, integrator_id, client_id)
-        self.assertEquals(
+        self.assertEqual(
             "https://external1.createsend.com/cd/create/ABCDEF12/DEADBEEF?url=FEEDDAD1", result.SessionUrl)
 
     # Test fake web mode
@@ -114,9 +114,9 @@ class CreateSendTestCase(object):
         try:
             c.create("", "", "")
         except BadRequest as br:
-            self.assertEquals(98798, br.data.Code)
-            self.assertEquals('A crazy API error', br.data.Message)
-            self.assertEquals(
+            self.assertEqual(98798, br.data.Code)
+            self.assertEqual('A crazy API error', br.data.Message)
+            self.assertEqual(
                 'The CreateSend API responded with the following error - 98798: A crazy API error', "%s" % br)
 
     def test_unauthorized(self):
@@ -125,9 +125,9 @@ class CreateSendTestCase(object):
         try:
             c.create("", "", "")
         except Unauthorized as ua:
-            self.assertEquals(98798, ua.data.Code)
-            self.assertEquals('A crazy API error', ua.data.Message)
-            self.assertEquals(
+            self.assertEqual(98798, ua.data.Code)
+            self.assertEqual('A crazy API error', ua.data.Message)
+            self.assertEqual(
                 'The CreateSend API responded with the following error - 98798: A crazy API error', "%s" % ua)
 
     # Test that the corresponding exceptions are raised according to the

--- a/test/test_journey.py
+++ b/test/test_journey.py
@@ -3,7 +3,7 @@ import unittest
 from createsend.journey import Journey
 
 
-class JourneyTestCase(object):
+class JourneyTestCase:
 
     def test_summary(self):
         self.journey.stub_request(

--- a/test/test_journey_email.py
+++ b/test/test_journey_email.py
@@ -1,10 +1,10 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.journey_email import JourneyEmail
 
 
-class JourneyEmailTestCase(object):
+class JourneyEmailTestCase:
 
     def test_bounces_no_params(self):
         self.journey_email.stub_request(self.no_param_uri_for("bounces"), "journey_email_bounces_no_params.json")
@@ -55,13 +55,13 @@ class JourneyEmailTestCase(object):
         self.assertEqual(click_one.Region, "New South Wales")
         self.assertEqual(click_one.CountryCode, "AU")
         self.assertEqual(click_one.CountryName, "Australia")
-        self.assertEquals(clicks.ResultsOrderedBy, "Date")
-        self.assertEquals(clicks.OrderDirection, "ASC")
-        self.assertEquals(clicks.PageNumber, 1)
-        self.assertEquals(clicks.PageSize, 1000)
-        self.assertEquals(clicks.RecordsOnThisPage, 2)
-        self.assertEquals(clicks.TotalNumberOfRecords, 2)
-        self.assertEquals(clicks.NumberOfPages, 1)
+        self.assertEqual(clicks.ResultsOrderedBy, "Date")
+        self.assertEqual(clicks.OrderDirection, "ASC")
+        self.assertEqual(clicks.PageNumber, 1)
+        self.assertEqual(clicks.PageSize, 1000)
+        self.assertEqual(clicks.RecordsOnThisPage, 2)
+        self.assertEqual(clicks.TotalNumberOfRecords, 2)
+        self.assertEqual(clicks.NumberOfPages, 1)
 
     def test_clicks_with_params(self):
         self.journey_email.stub_request(self.param_uri_for("clicks", "2019-01-01", 1, 10, "desc"), "journey_email_clicks_with_params.json")
@@ -78,13 +78,13 @@ class JourneyEmailTestCase(object):
         self.assertEqual(click_one.Region, "New South Wales")
         self.assertEqual(click_one.CountryCode, "AU")
         self.assertEqual(click_one.CountryName, "Australia")
-        self.assertEquals(clicks.ResultsOrderedBy, "Date")
-        self.assertEquals(clicks.OrderDirection, "DESC")
-        self.assertEquals(clicks.PageNumber, 1)
-        self.assertEquals(clicks.PageSize, 10)
-        self.assertEquals(clicks.RecordsOnThisPage, 2)
-        self.assertEquals(clicks.TotalNumberOfRecords, 2)
-        self.assertEquals(clicks.NumberOfPages, 1)
+        self.assertEqual(clicks.ResultsOrderedBy, "Date")
+        self.assertEqual(clicks.OrderDirection, "DESC")
+        self.assertEqual(clicks.PageNumber, 1)
+        self.assertEqual(clicks.PageSize, 10)
+        self.assertEqual(clicks.RecordsOnThisPage, 2)
+        self.assertEqual(clicks.TotalNumberOfRecords, 2)
+        self.assertEqual(clicks.NumberOfPages, 1)
 
     def test_opens_no_params(self):
         self.journey_email.stub_request(self.no_param_uri_for("opens"), "journey_email_opens_no_params.json")
@@ -100,13 +100,13 @@ class JourneyEmailTestCase(object):
         self.assertEqual(open_one.Region, "New South Wales")
         self.assertEqual(open_one.CountryCode, "AU")
         self.assertEqual(open_one.CountryName, "Australia")
-        self.assertEquals(opens.ResultsOrderedBy, "Date")
-        self.assertEquals(opens.OrderDirection, "ASC")
-        self.assertEquals(opens.PageNumber, 1)
-        self.assertEquals(opens.PageSize, 1000)
-        self.assertEquals(opens.RecordsOnThisPage, 2)
-        self.assertEquals(opens.TotalNumberOfRecords, 2)
-        self.assertEquals(opens.NumberOfPages, 1)
+        self.assertEqual(opens.ResultsOrderedBy, "Date")
+        self.assertEqual(opens.OrderDirection, "ASC")
+        self.assertEqual(opens.PageNumber, 1)
+        self.assertEqual(opens.PageSize, 1000)
+        self.assertEqual(opens.RecordsOnThisPage, 2)
+        self.assertEqual(opens.TotalNumberOfRecords, 2)
+        self.assertEqual(opens.NumberOfPages, 1)
 
     def test_opens_with_params(self):
         self.journey_email.stub_request(self.param_uri_for("opens", "2019-01-01", 1, 10, "desc"), "journey_email_opens_with_params.json")
@@ -122,13 +122,13 @@ class JourneyEmailTestCase(object):
         self.assertEqual(open_one.Region, "New South Wales")
         self.assertEqual(open_one.CountryCode, "AU")
         self.assertEqual(open_one.CountryName, "Australia")
-        self.assertEquals(opens.ResultsOrderedBy, "Date")
-        self.assertEquals(opens.OrderDirection, "DESC")
-        self.assertEquals(opens.PageNumber, 1)
-        self.assertEquals(opens.PageSize, 10)
-        self.assertEquals(opens.RecordsOnThisPage, 2)
-        self.assertEquals(opens.TotalNumberOfRecords, 2)
-        self.assertEquals(opens.NumberOfPages, 1)
+        self.assertEqual(opens.ResultsOrderedBy, "Date")
+        self.assertEqual(opens.OrderDirection, "DESC")
+        self.assertEqual(opens.PageNumber, 1)
+        self.assertEqual(opens.PageSize, 10)
+        self.assertEqual(opens.RecordsOnThisPage, 2)
+        self.assertEqual(opens.TotalNumberOfRecords, 2)
+        self.assertEqual(opens.NumberOfPages, 1)
 
     def test_recipients_no_params(self):
         self.journey_email.stub_request(self.no_param_uri_for("recipients"), "journey_email_recipients_no_params.json")

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -1,27 +1,25 @@
-# -*- coding: utf-8 -*-
-
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.list import List
 
 
-class ListTestCase(object):
+class ListTestCase:
 
     def test_create_without_unsubscribe_setting(self):
         l = List()
         l.stub_request("lists/%s.json" % self.client_id, "create_list.json")
         list_id = l.create(self.client_id, "List One", "", False, "")
-        self.assertEquals(list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
-        self.assertEquals(l.list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
+        self.assertEqual(list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
+        self.assertEqual(l.list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
 
     def test_create_with_unsubscribe_setting(self):
         l = List()
         l.stub_request("lists/%s.json" % self.client_id, "create_list.json")
         list_id = l.create(self.client_id, "List One",
                            "", False, "", "OnlyThisList")
-        self.assertEquals(list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
-        self.assertEquals(l.list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
+        self.assertEqual(list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
+        self.assertEqual(l.list_id, "e3c5f034d68744f7881fdccf13c2daee1234")
 
     def test_update_without_unsubscribe_setting(self):
         self.list.stub_request("lists/%s.json" % self.list.list_id, None)
@@ -46,7 +44,7 @@ class ListTestCase(object):
                                "{\"DataType\": \"Date\", \"FieldName\": \"new date field\", \"Options\": [], \"VisibleInPreferenceCenter\": true}")
         personalisation_tag = self.list.create_custom_field(
             "new date field", "Date")
-        self.assertEquals(personalisation_tag, "[newdatefield]")
+        self.assertEqual(personalisation_tag, "[newdatefield]")
 
     def test_create_custom_field_with_options_and_visible_in_preference_center(self):
         options = ["one", "two"]
@@ -55,16 +53,16 @@ class ListTestCase(object):
                                "{\"DataType\": \"MultiSelectOne\", \"FieldName\": \"newsletter format\", \"Options\": [\"one\", \"two\"], \"VisibleInPreferenceCenter\": false}")
         personalisation_tag = self.list.create_custom_field("newsletter format",
                                                             "MultiSelectOne", options, False)
-        self.assertEquals(personalisation_tag, "[newdatefield]")
+        self.assertEqual(personalisation_tag, "[newdatefield]")
 
     def test_update_custom_field(self):
         key = "[mycustomfield]"
-        self.list.stub_request("lists/%s/customfields/%s.json" % (self.list.list_id, quote(key)),
+        self.list.stub_request("lists/{}/customfields/{}.json".format(self.list.list_id, quote(key)),
                                "update_custom_field.json", None,
                                "{\"FieldName\": \"my renamed custom field\", \"VisibleInPreferenceCenter\": true}")
         personalisation_tag = self.list.update_custom_field(
             key, "my renamed custom field", True)
-        self.assertEquals(personalisation_tag, "[myrenamedcustomfield]")
+        self.assertEqual(personalisation_tag, "[myrenamedcustomfield]")
 
     def test_delete_custom_field(self):
         custom_field_key = "[newdatefield]"
@@ -84,217 +82,217 @@ class ListTestCase(object):
         self.list.stub_request("lists/%s.json" %
                                self.list.list_id, "list_details.json")
         details = self.list.details()
-        self.assertEquals(details.ConfirmedOptIn, False)
-        self.assertEquals(details.Title, "a non-basic list :)")
-        self.assertEquals(details.UnsubscribePage, "")
-        self.assertEquals(details.ListID, "2fe4c8f0373ce320e2200596d7ef168f")
-        self.assertEquals(details.ConfirmationSuccessPage, "")
+        self.assertEqual(details.ConfirmedOptIn, False)
+        self.assertEqual(details.Title, "a non-basic list :)")
+        self.assertEqual(details.UnsubscribePage, "")
+        self.assertEqual(details.ListID, "2fe4c8f0373ce320e2200596d7ef168f")
+        self.assertEqual(details.ConfirmationSuccessPage, "")
 
     def test_custom_fields(self):
         self.list.stub_request("lists/%s/customfields.json" %
                                self.list.list_id, "custom_fields.json")
         cfs = self.list.custom_fields()
-        self.assertEquals(len(cfs), 3)
-        self.assertEquals(cfs[0].FieldName, "website")
-        self.assertEquals(cfs[0].Key, "[website]")
-        self.assertEquals(cfs[0].DataType, "Text")
-        self.assertEquals(cfs[0].FieldOptions, [])
-        self.assertEquals(cfs[0].VisibleInPreferenceCenter, True)
+        self.assertEqual(len(cfs), 3)
+        self.assertEqual(cfs[0].FieldName, "website")
+        self.assertEqual(cfs[0].Key, "[website]")
+        self.assertEqual(cfs[0].DataType, "Text")
+        self.assertEqual(cfs[0].FieldOptions, [])
+        self.assertEqual(cfs[0].VisibleInPreferenceCenter, True)
 
     def test_custom_fields_utf8(self):
         self.list.stub_request("lists/%s/customfields.json" %
                                self.list.list_id, "custom_fields_utf8.json")
         cfs = self.list.custom_fields()
-        self.assertEquals(len(cfs), 2)
-        self.assertEquals(cfs[0].FieldName, "salary_range")
-        self.assertEquals(cfs[0].FieldOptions, [
-                          u"£0-20k", u"£20-30k", u"£30k+"])
+        self.assertEqual(len(cfs), 2)
+        self.assertEqual(cfs[0].FieldName, "salary_range")
+        self.assertEqual(cfs[0].FieldOptions, [
+                          "£0-20k", "£20-30k", "£30k+"])
 
     def test_segments(self):
         self.list.stub_request("lists/%s/segments.json" %
                                self.list.list_id, "segments.json")
         segments = self.list.segments()
-        self.assertEquals(len(segments), 2)
-        self.assertEquals(segments[0].ListID,
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[0].ListID,
                           'a58ee1d3039b8bec838e6d1482a8a965')
-        self.assertEquals(segments[0].SegmentID,
+        self.assertEqual(segments[0].SegmentID,
                           '46aa5e01fd43381863d4e42cf277d3a9')
-        self.assertEquals(segments[0].Title, 'Segment One')
+        self.assertEqual(segments[0].Title, 'Segment One')
 
     def test_stats(self):
         self.list.stub_request("lists/%s/stats.json" %
                                self.list.list_id, "list_stats.json")
         stats = self.list.stats()
-        self.assertEquals(stats.TotalActiveSubscribers, 6)
-        self.assertEquals(stats.TotalUnsubscribes, 2)
-        self.assertEquals(stats.TotalDeleted, 0)
-        self.assertEquals(stats.TotalBounces, 0)
+        self.assertEqual(stats.TotalActiveSubscribers, 6)
+        self.assertEqual(stats.TotalUnsubscribes, 2)
+        self.assertEqual(stats.TotalDeleted, 0)
+        self.assertEqual(stats.TotalBounces, 0)
 
     def test_active(self):
         min_date = "2010-01-01"
         self.list.stub_request("lists/%s/active.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackingpreference=False" %
                                (self.list.list_id, quote(min_date)), "active_subscribers.json")
         res = self.list.active(min_date)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 5)
-        self.assertEquals(res.TotalNumberOfRecords, 5)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 5)
-        self.assertEquals(res.Results[0].EmailAddress,
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 5)
+        self.assertEqual(res.TotalNumberOfRecords, 5)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 5)
+        self.assertEqual(res.Results[0].EmailAddress,
                           "subs+7t8787Y@example.com")
-        self.assertEquals(res.Results[0].Name, "Person One")
-        self.assertEquals(res.Results[0].Date, "2010-10-25 10:28:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-24 10:28:00")
-        self.assertEquals(res.Results[0].State, "Active")
-        self.assertEquals(len(res.Results[0].CustomFields), 5)
-        self.assertEquals(res.Results[0].CustomFields[0].Key, "website")
-        self.assertEquals(res.Results[0].CustomFields[
+        self.assertEqual(res.Results[0].Name, "Person One")
+        self.assertEqual(res.Results[0].Date, "2010-10-25 10:28:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-24 10:28:00")
+        self.assertEqual(res.Results[0].State, "Active")
+        self.assertEqual(len(res.Results[0].CustomFields), 5)
+        self.assertEqual(res.Results[0].CustomFields[0].Key, "website")
+        self.assertEqual(res.Results[0].CustomFields[
                           0].Value, "http://example.com")
-        self.assertEquals(res.Results[0].CustomFields[
+        self.assertEqual(res.Results[0].CustomFields[
                           1].Key, "multi select field")
-        self.assertEquals(res.Results[0].CustomFields[1].Value, "option one")
-        self.assertEquals(res.Results[0].CustomFields[
+        self.assertEqual(res.Results[0].CustomFields[1].Value, "option one")
+        self.assertEqual(res.Results[0].CustomFields[
                           2].Key, "multi select field")
-        self.assertEquals(res.Results[0].CustomFields[2].Value, "option two")
-        self.assertEquals(res.Results[0].ReadsEmailWith, "Gmail")
+        self.assertEqual(res.Results[0].CustomFields[2].Value, "option two")
+        self.assertEqual(res.Results[0].ReadsEmailWith, "Gmail")
 
     def test_active_with_tracking_preference_included(self):
         min_date = "2010-01-01"
         self.list.stub_request("lists/%s/active.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackingpreference=True" %
                                (self.list.list_id, quote(min_date)), "active_subscribers_with_tracking_preference.json")
         res = self.list.active(min_date, include_tracking_preference=True)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 5)
-        self.assertEquals(res.TotalNumberOfRecords, 5)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 5)
-        self.assertEquals(res.Results[0].EmailAddress,
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 5)
+        self.assertEqual(res.TotalNumberOfRecords, 5)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 5)
+        self.assertEqual(res.Results[0].EmailAddress,
                           "subs+7t8787Y@example.com")
-        self.assertEquals(res.Results[0].Name, "Person One")
-        self.assertEquals(res.Results[0].Date, "2010-10-25 10:28:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-24 10:28:00")
-        self.assertEquals(res.Results[0].State, "Active")
-        self.assertEquals(len(res.Results[0].CustomFields), 5)
-        self.assertEquals(res.Results[0].CustomFields[0].Key, "website")
-        self.assertEquals(res.Results[0].CustomFields[
+        self.assertEqual(res.Results[0].Name, "Person One")
+        self.assertEqual(res.Results[0].Date, "2010-10-25 10:28:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-24 10:28:00")
+        self.assertEqual(res.Results[0].State, "Active")
+        self.assertEqual(len(res.Results[0].CustomFields), 5)
+        self.assertEqual(res.Results[0].CustomFields[0].Key, "website")
+        self.assertEqual(res.Results[0].CustomFields[
                           0].Value, "http://example.com")
-        self.assertEquals(res.Results[0].CustomFields[
+        self.assertEqual(res.Results[0].CustomFields[
                           1].Key, "multi select field")
-        self.assertEquals(res.Results[0].CustomFields[1].Value, "option one")
-        self.assertEquals(res.Results[0].CustomFields[
+        self.assertEqual(res.Results[0].CustomFields[1].Value, "option one")
+        self.assertEqual(res.Results[0].CustomFields[
                           2].Key, "multi select field")
-        self.assertEquals(res.Results[0].CustomFields[2].Value, "option two")
-        self.assertEquals(res.Results[0].ReadsEmailWith, "Gmail")
-        self.assertEquals(res.Results[0].ConsentToTrack, "Yes")
+        self.assertEqual(res.Results[0].CustomFields[2].Value, "option two")
+        self.assertEqual(res.Results[0].ReadsEmailWith, "Gmail")
+        self.assertEqual(res.Results[0].ConsentToTrack, "Yes")
 
     def test_unconfirmed(self):
         min_date = "2010-01-01"
         self.list.stub_request("lists/%s/unconfirmed.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackingpreference=False" %
                                (self.list.list_id, quote(min_date)), "unconfirmed_subscribers.json")
         res = self.list.unconfirmed(min_date)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 2)
-        self.assertEquals(res.TotalNumberOfRecords, 2)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 2)
-        self.assertEquals(res.Results[0].EmailAddress,
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 2)
+        self.assertEqual(res.TotalNumberOfRecords, 2)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 2)
+        self.assertEqual(res.Results[0].EmailAddress,
                           "subs+7t8787Y@example.com")
-        self.assertEquals(res.Results[0].Name, "Unconfirmed One")
-        self.assertEquals(res.Results[0].State, "Unconfirmed")
+        self.assertEqual(res.Results[0].Name, "Unconfirmed One")
+        self.assertEqual(res.Results[0].State, "Unconfirmed")
 
     def test_unsubscribed(self):
         min_date = "2010-01-01"
         self.list.stub_request("lists/%s/unsubscribed.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackingpreference=False" %
                                (self.list.list_id, quote(min_date)), "unsubscribed_subscribers.json")
         res = self.list.unsubscribed(min_date)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 5)
-        self.assertEquals(res.TotalNumberOfRecords, 5)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 5)
-        self.assertEquals(
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 5)
+        self.assertEqual(res.TotalNumberOfRecords, 5)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 5)
+        self.assertEqual(
             res.Results[0].EmailAddress, "subscriber@example.com")
-        self.assertEquals(res.Results[0].Name, "Unsub One")
-        self.assertEquals(res.Results[0].Date, "2010-10-25 13:11:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-25 13:11:00")
-        self.assertEquals(res.Results[0].State, "Unsubscribed")
-        self.assertEquals(len(res.Results[0].CustomFields), 0)
-        self.assertEquals(res.Results[0].ReadsEmailWith, "Gmail")
+        self.assertEqual(res.Results[0].Name, "Unsub One")
+        self.assertEqual(res.Results[0].Date, "2010-10-25 13:11:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-25 13:11:00")
+        self.assertEqual(res.Results[0].State, "Unsubscribed")
+        self.assertEqual(len(res.Results[0].CustomFields), 0)
+        self.assertEqual(res.Results[0].ReadsEmailWith, "Gmail")
 
     def test_deleted(self):
         min_date = "2010-01-01"
         self.list.stub_request("lists/%s/deleted.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackingpreference=False" %
                                (self.list.list_id, quote(min_date)), "deleted_subscribers.json")
         res = self.list.deleted(min_date)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 5)
-        self.assertEquals(res.TotalNumberOfRecords, 5)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 5)
-        self.assertEquals(
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 5)
+        self.assertEqual(res.TotalNumberOfRecords, 5)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 5)
+        self.assertEqual(
             res.Results[0].EmailAddress, "subscriber@example.com")
-        self.assertEquals(res.Results[0].Name, "Deleted One")
-        self.assertEquals(res.Results[0].Date, "2010-10-25 13:11:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-25 13:11:00")
-        self.assertEquals(res.Results[0].State, "Deleted")
-        self.assertEquals(len(res.Results[0].CustomFields), 0)
-        self.assertEquals(res.Results[0].ReadsEmailWith, "Gmail")
+        self.assertEqual(res.Results[0].Name, "Deleted One")
+        self.assertEqual(res.Results[0].Date, "2010-10-25 13:11:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-25 13:11:00")
+        self.assertEqual(res.Results[0].State, "Deleted")
+        self.assertEqual(len(res.Results[0].CustomFields), 0)
+        self.assertEqual(res.Results[0].ReadsEmailWith, "Gmail")
 
     def test_bounced(self):
         min_date = "2010-01-01"
         self.list.stub_request("lists/%s/bounced.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackingpreference=False" %
                                (self.list.list_id, quote(min_date)), "bounced_subscribers.json")
         res = self.list.bounced(min_date)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 1)
-        self.assertEquals(res.TotalNumberOfRecords, 1)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 1)
-        self.assertEquals(res.Results[0].EmailAddress,
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 1)
+        self.assertEqual(res.TotalNumberOfRecords, 1)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 1)
+        self.assertEqual(res.Results[0].EmailAddress,
                           "bouncedsubscriber@example.com")
-        self.assertEquals(res.Results[0].Name, "Bounced One")
-        self.assertEquals(res.Results[0].Date, "2010-10-25 13:11:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-25 13:11:00")
-        self.assertEquals(res.Results[0].State, "Bounced")
-        self.assertEquals(len(res.Results[0].CustomFields), 0)
-        self.assertEquals(res.Results[0].ReadsEmailWith, "")
+        self.assertEqual(res.Results[0].Name, "Bounced One")
+        self.assertEqual(res.Results[0].Date, "2010-10-25 13:11:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-25 13:11:00")
+        self.assertEqual(res.Results[0].State, "Bounced")
+        self.assertEqual(len(res.Results[0].CustomFields), 0)
+        self.assertEqual(res.Results[0].ReadsEmailWith, "")
 
     def test_webhooks(self):
         self.list.stub_request("lists/%s/webhooks.json" %
                                self.list.list_id, "list_webhooks.json")
         hooks = self.list.webhooks()
-        self.assertEquals(len(hooks), 2)
-        self.assertEquals(hooks[0].WebhookID, "943678317049bc13")
-        self.assertEquals(len(hooks[0].Events), 1)
-        self.assertEquals(hooks[0].Events[0], "Deactivate")
-        self.assertEquals(hooks[0].Url, "http://www.postbin.org/d9w8ud9wud9w")
-        self.assertEquals(hooks[0].Status, "Active")
-        self.assertEquals(hooks[0].PayloadFormat, "Json")
+        self.assertEqual(len(hooks), 2)
+        self.assertEqual(hooks[0].WebhookID, "943678317049bc13")
+        self.assertEqual(len(hooks[0].Events), 1)
+        self.assertEqual(hooks[0].Events[0], "Deactivate")
+        self.assertEqual(hooks[0].Url, "http://www.postbin.org/d9w8ud9wud9w")
+        self.assertEqual(hooks[0].Status, "Active")
+        self.assertEqual(hooks[0].PayloadFormat, "Json")
 
     def test_create_webhook(self):
         self.list.stub_request("lists/%s/webhooks.json" %
                                self.list.list_id, "create_list_webhook.json")
         webhook_id = self.list.create_webhook(
             ["Unsubscribe", "Spam"], "http://example.com/unsub", "json")
-        self.assertEquals(webhook_id, "6a783d359bd44ef62c6ca0d3eda4412a")
+        self.assertEqual(webhook_id, "6a783d359bd44ef62c6ca0d3eda4412a")
 
     def test_test_webhook(self):
         webhook_id = "jiuweoiwueoiwueowiueo"
@@ -317,7 +315,7 @@ class ListTestCase(object):
     def test_deactivate_webhook(self):
         webhook_id = "jiuweoiwueoiwueowiueo"
         self.list.stub_request(
-            "lists/%s/webhooks/%s/deactivate.json" % (self.list.list_id, webhook_id), None)
+            "lists/{}/webhooks/{}/deactivate.json".format(self.list.list_id, webhook_id), None)
         self.list.deactivate_webhook(webhook_id)
 
 

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -57,7 +57,7 @@ class ListTestCase:
 
     def test_update_custom_field(self):
         key = "[mycustomfield]"
-        self.list.stub_request("lists/{}/customfields/{}.json".format(self.list.list_id, quote(key)),
+        self.list.stub_request(f"lists/{self.list.list_id}/customfields/{quote(key)}.json",
                                "update_custom_field.json", None,
                                "{\"FieldName\": \"my renamed custom field\", \"VisibleInPreferenceCenter\": true}")
         personalisation_tag = self.list.update_custom_field(
@@ -315,7 +315,7 @@ class ListTestCase:
     def test_deactivate_webhook(self):
         webhook_id = "jiuweoiwueoiwueowiueo"
         self.list.stub_request(
-            "lists/{}/webhooks/{}/deactivate.json".format(self.list.list_id, webhook_id), None)
+            f"lists/{self.list.list_id}/webhooks/{webhook_id}/deactivate.json", None)
         self.list.deactivate_webhook(webhook_id)
 
 

--- a/test/test_people.py
+++ b/test/test_people.py
@@ -1,44 +1,44 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.person import Person
 
 
-class PeopleTestCase(object):
+class PeopleTestCase:
 
     def test_get(self):
         email = "person@example.com"
         self.person.stub_request("clients/%s/people.json?email=%s" %
                                  (self.client_id, quote(email)), "person_details.json")
         person = self.person.get(self.client_id, email)
-        self.assertEquals(person.EmailAddress, email)
-        self.assertEquals(person.Name, "Person One")
-        self.assertEquals(person.AccessLevel, 1023)
-        self.assertEquals(person.Status, "Active")
+        self.assertEqual(person.EmailAddress, email)
+        self.assertEqual(person.Name, "Person One")
+        self.assertEqual(person.AccessLevel, 1023)
+        self.assertEqual(person.Status, "Active")
 
     def test_get_without_args(self):
         email = "person@example.com"
         self.person.stub_request("clients/%s/people.json?email=%s" %
                                  (self.client_id, quote(email)), "person_details.json")
         person = self.person.get()
-        self.assertEquals(person.EmailAddress, email)
-        self.assertEquals(person.Name, "Person One")
-        self.assertEquals(person.AccessLevel, 1023)
-        self.assertEquals(person.Status, "Active")
+        self.assertEqual(person.EmailAddress, email)
+        self.assertEqual(person.Name, "Person One")
+        self.assertEqual(person.AccessLevel, 1023)
+        self.assertEqual(person.Status, "Active")
 
     def test_add(self):
         self.person.stub_request("clients/%s/people.json" %
                                  self.client_id, "add_person.json")
         result = self.person.add(
             self.client_id, "person@example.com", "Person Name", 1023, "Password")
-        self.assertEquals(result.EmailAddress, "person@example.com")
+        self.assertEqual(result.EmailAddress, "person@example.com")
 
     def test_update(self):
         new_email = "new_email_address@example.com"
         self.person.stub_request("clients/%s/people.json?email=%s" %
                                  (self.client_id, quote(self.person.email_address)), None)
         self.person.update(new_email, "Person New Name", 31, 'blah')
-        self.assertEquals(self.person.email_address, new_email)
+        self.assertEqual(self.person.email_address, new_email)
 
     def test_delete(self):
         self.person.stub_request("clients/%s/people.json?email=%s" %

--- a/test/test_segment.py
+++ b/test/test_segment.py
@@ -1,10 +1,10 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.segment import Segment
 
 
-class SegmentTestCase(object):
+class SegmentTestCase:
 
     def test_create(self):
         list_id = "2983492834987394879837498"
@@ -14,8 +14,8 @@ class SegmentTestCase(object):
         s.stub_request("segments/%s.json" % list_id, "create_segment.json", None,
                        "{\"RuleGroups\": [{\"Rules\": [{\"Clause\": \"CONTAINS example.com\", \"RuleType\": \"EmailAddress\"}, {\"Clause\": \"EQUALS subscriber\", \"RuleType\": \"Name\"}]}], \"Title\": \"new segment title\"}")
         segment_id = s.create(list_id, "new segment title", rulegroups)
-        self.assertEquals(segment_id, "0246c2aea610a3545d9780bf6ab890061234")
-        self.assertEquals(s.segment_id, "0246c2aea610a3545d9780bf6ab890061234")
+        self.assertEqual(segment_id, "0246c2aea610a3545d9780bf6ab890061234")
+        self.assertEqual(s.segment_id, "0246c2aea610a3545d9780bf6ab890061234")
 
     def test_update(self):
         rulegroups = [
@@ -36,41 +36,41 @@ class SegmentTestCase(object):
         self.segment.stub_request("segments/%s/active.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackinginformation=False" %
                                   (self.segment.segment_id, quote(min_date)), "segment_subscribers.json")
         res = self.segment.subscribers(min_date)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 2)
-        self.assertEquals(res.TotalNumberOfRecords, 2)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 2)
-        self.assertEquals(res.Results[0].EmailAddress, "personone@example.com")
-        self.assertEquals(res.Results[0].Name, "Person One")
-        self.assertEquals(res.Results[0].Date, "2010-10-27 13:13:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-27 13:13:00")
-        self.assertEquals(res.Results[0].State, "Active")
-        self.assertEquals(res.Results[0].CustomFields, [])
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 2)
+        self.assertEqual(res.TotalNumberOfRecords, 2)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 2)
+        self.assertEqual(res.Results[0].EmailAddress, "personone@example.com")
+        self.assertEqual(res.Results[0].Name, "Person One")
+        self.assertEqual(res.Results[0].Date, "2010-10-27 13:13:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-27 13:13:00")
+        self.assertEqual(res.Results[0].State, "Active")
+        self.assertEqual(res.Results[0].CustomFields, [])
 
     def test_subscribers_with_tracking_information_included(self):
         min_date = "2010-01-01"
         self.segment.stub_request("segments/%s/active.json?date=%s&orderfield=email&page=1&pagesize=1000&orderdirection=asc&includetrackinginformation=True" %
                                   (self.segment.segment_id, quote(min_date)), "segment_subscribers_with_tracking_preference.json")
         res = self.segment.subscribers(min_date, include_tracking_information=True)
-        self.assertEquals(res.ResultsOrderedBy, "email")
-        self.assertEquals(res.OrderDirection, "asc")
-        self.assertEquals(res.PageNumber, 1)
-        self.assertEquals(res.PageSize, 1000)
-        self.assertEquals(res.RecordsOnThisPage, 2)
-        self.assertEquals(res.TotalNumberOfRecords, 2)
-        self.assertEquals(res.NumberOfPages, 1)
-        self.assertEquals(len(res.Results), 2)
-        self.assertEquals(res.Results[0].EmailAddress, "personone@example.com")
-        self.assertEquals(res.Results[0].Name, "Person One")
-        self.assertEquals(res.Results[0].Date, "2010-10-27 13:13:00")
-        self.assertEquals(res.Results[0].ListJoinedDate, "2010-10-27 13:13:00")
-        self.assertEquals(res.Results[0].State, "Active")
-        self.assertEquals(res.Results[0].CustomFields, [])
-        self.assertEquals(res.Results[0].ConsentToTrack, "Yes")
+        self.assertEqual(res.ResultsOrderedBy, "email")
+        self.assertEqual(res.OrderDirection, "asc")
+        self.assertEqual(res.PageNumber, 1)
+        self.assertEqual(res.PageSize, 1000)
+        self.assertEqual(res.RecordsOnThisPage, 2)
+        self.assertEqual(res.TotalNumberOfRecords, 2)
+        self.assertEqual(res.NumberOfPages, 1)
+        self.assertEqual(len(res.Results), 2)
+        self.assertEqual(res.Results[0].EmailAddress, "personone@example.com")
+        self.assertEqual(res.Results[0].Name, "Person One")
+        self.assertEqual(res.Results[0].Date, "2010-10-27 13:13:00")
+        self.assertEqual(res.Results[0].ListJoinedDate, "2010-10-27 13:13:00")
+        self.assertEqual(res.Results[0].State, "Active")
+        self.assertEqual(res.Results[0].CustomFields, [])
+        self.assertEqual(res.Results[0].ConsentToTrack, "Yes")
 
     def test_delete(self):
         self.segment.stub_request("segments/%s.json" %
@@ -86,16 +86,16 @@ class SegmentTestCase(object):
         self.segment.stub_request("segments/%s.json" %
                                   self.segment.segment_id, "segment_details.json")
         res = self.segment.details()
-        self.assertEquals(res.ActiveSubscribers, 0)
-        self.assertEquals(len(res.RuleGroups), 2)
-        self.assertEquals(res.RuleGroups[0].Rules[0].RuleType, "EmailAddress")
-        self.assertEquals(res.RuleGroups[0].Rules[
+        self.assertEqual(res.ActiveSubscribers, 0)
+        self.assertEqual(len(res.RuleGroups), 2)
+        self.assertEqual(res.RuleGroups[0].Rules[0].RuleType, "EmailAddress")
+        self.assertEqual(res.RuleGroups[0].Rules[
                           0].Clause, "CONTAINS @hello.com")
-        self.assertEquals(res.RuleGroups[1].Rules[0].RuleType, "Name")
-        self.assertEquals(res.RuleGroups[1].Rules[0].Clause, "PROVIDED")
-        self.assertEquals(res.ListID, "2bea949d0bf96148c3e6a209d2e82060")
-        self.assertEquals(res.SegmentID, "dba84a225d5ce3d19105d7257baac46f")
-        self.assertEquals(res.Title, "My Segment")
+        self.assertEqual(res.RuleGroups[1].Rules[0].RuleType, "Name")
+        self.assertEqual(res.RuleGroups[1].Rules[0].Clause, "PROVIDED")
+        self.assertEqual(res.ListID, "2bea949d0bf96148c3e6a209d2e82060")
+        self.assertEqual(res.SegmentID, "dba84a225d5ce3d19105d7257baac46f")
+        self.assertEqual(res.Title, "My Segment")
 
 
 class OAuthSegmentTestCase(unittest.TestCase, SegmentTestCase):

--- a/test/test_subscriber.py
+++ b/test/test_subscriber.py
@@ -1,67 +1,67 @@
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import unittest
 
 from createsend.createsend import BadRequest
 from createsend.subscriber import Subscriber
 
 
-class SubscriberTestCase(object):
+class SubscriberTestCase:
 
     def test_get(self):
         email = "subscriber@example.com"
         self.subscriber.stub_request("subscribers/%s.json?email=%s&includetrackingpreference=False" %
                                      (self.list_id, quote(email)), "subscriber_details.json")
         subscriber = self.subscriber.get(self.list_id, email)
-        self.assertEquals(subscriber.EmailAddress, email)
-        self.assertEquals(subscriber.Name, "Subscriber One")
-        self.assertEquals(subscriber.Date, "2010-10-25 10:28:00")
-        self.assertEquals(subscriber.ListJoinedDate, "2010-10-25 10:28:00")
-        self.assertEquals(subscriber.State, "Active")
-        self.assertEquals(len(subscriber.CustomFields), 3)
-        self.assertEquals(subscriber.CustomFields[0].Key, 'website')
-        self.assertEquals(subscriber.CustomFields[
+        self.assertEqual(subscriber.EmailAddress, email)
+        self.assertEqual(subscriber.Name, "Subscriber One")
+        self.assertEqual(subscriber.Date, "2010-10-25 10:28:00")
+        self.assertEqual(subscriber.ListJoinedDate, "2010-10-25 10:28:00")
+        self.assertEqual(subscriber.State, "Active")
+        self.assertEqual(len(subscriber.CustomFields), 3)
+        self.assertEqual(subscriber.CustomFields[0].Key, 'website')
+        self.assertEqual(subscriber.CustomFields[
                           0].Value, 'http://example.com')
-        self.assertEquals(subscriber.ReadsEmailWith, "Gmail")
+        self.assertEqual(subscriber.ReadsEmailWith, "Gmail")
 
     def test_get_without_arguments(self):
         email = "subscriber@example.com"
         self.subscriber.stub_request("subscribers/%s.json?email=%s&includetrackingpreference=False" %
                                      (self.list_id, quote(email)), "subscriber_details.json")
         subscriber = self.subscriber.get()
-        self.assertEquals(subscriber.EmailAddress, email)
-        self.assertEquals(subscriber.Name, "Subscriber One")
-        self.assertEquals(subscriber.Date, "2010-10-25 10:28:00")
-        self.assertEquals(subscriber.ListJoinedDate, "2010-10-25 10:28:00")
-        self.assertEquals(subscriber.State, "Active")
-        self.assertEquals(len(subscriber.CustomFields), 3)
-        self.assertEquals(subscriber.CustomFields[0].Key, 'website')
-        self.assertEquals(subscriber.CustomFields[
+        self.assertEqual(subscriber.EmailAddress, email)
+        self.assertEqual(subscriber.Name, "Subscriber One")
+        self.assertEqual(subscriber.Date, "2010-10-25 10:28:00")
+        self.assertEqual(subscriber.ListJoinedDate, "2010-10-25 10:28:00")
+        self.assertEqual(subscriber.State, "Active")
+        self.assertEqual(len(subscriber.CustomFields), 3)
+        self.assertEqual(subscriber.CustomFields[0].Key, 'website')
+        self.assertEqual(subscriber.CustomFields[
                           0].Value, 'http://example.com')
-        self.assertEquals(subscriber.ReadsEmailWith, "Gmail")
+        self.assertEqual(subscriber.ReadsEmailWith, "Gmail")
 
     def test_get_with_tracking_preference_included(self):
         email = "subscriber@example.com"
         self.subscriber.stub_request("subscribers/%s.json?email=%s&includetrackingpreference=True" %
                                      (self.list_id, quote(email)), "subscriber_details_with_tracking_preference.json")
         subscriber = self.subscriber.get(self.list_id, email, include_tracking_preference=True)
-        self.assertEquals(subscriber.EmailAddress, email)
-        self.assertEquals(subscriber.Name, "Subscriber One")
-        self.assertEquals(subscriber.Date, "2010-10-25 10:28:00")
-        self.assertEquals(subscriber.ListJoinedDate, "2010-10-25 10:28:00")
-        self.assertEquals(subscriber.State, "Active")
-        self.assertEquals(len(subscriber.CustomFields), 3)
-        self.assertEquals(subscriber.CustomFields[0].Key, 'website')
-        self.assertEquals(subscriber.CustomFields[
+        self.assertEqual(subscriber.EmailAddress, email)
+        self.assertEqual(subscriber.Name, "Subscriber One")
+        self.assertEqual(subscriber.Date, "2010-10-25 10:28:00")
+        self.assertEqual(subscriber.ListJoinedDate, "2010-10-25 10:28:00")
+        self.assertEqual(subscriber.State, "Active")
+        self.assertEqual(len(subscriber.CustomFields), 3)
+        self.assertEqual(subscriber.CustomFields[0].Key, 'website')
+        self.assertEqual(subscriber.CustomFields[
                           0].Value, 'http://example.com')
-        self.assertEquals(subscriber.ReadsEmailWith, "Gmail")
-        self.assertEquals(subscriber.ConsentToTrack, "Yes")
+        self.assertEqual(subscriber.ReadsEmailWith, "Gmail")
+        self.assertEqual(subscriber.ConsentToTrack, "Yes")
 
     def test_add_without_custom_fields(self):
         self.subscriber.stub_request(
             "subscribers/%s.json" % self.list_id, "add_subscriber.json")
         email_address = self.subscriber.add(
             self.list_id, "subscriber@example.com", "Subscriber", [], True, "Unchanged")
-        self.assertEquals(email_address, "subscriber@example.com")
+        self.assertEqual(email_address, "subscriber@example.com")
 
     def test_add_with_custom_fields(self):
         self.subscriber.stub_request(
@@ -69,7 +69,7 @@ class SubscriberTestCase(object):
         custom_fields = [{"Key": 'website', "Value": 'http://example.com/'}]
         email_address = self.subscriber.add(
             self.list_id, "subscriber@example.com", "Subscriber", custom_fields, True, "No")
-        self.assertEquals(email_address, "subscriber@example.com")
+        self.assertEqual(email_address, "subscriber@example.com")
 
     def test_add_with_custom_fields_including_multioption(self):
         self.subscriber.stub_request(
@@ -79,7 +79,7 @@ class SubscriberTestCase(object):
                          {"Key": 'multioptionselectmany', "Value": 'secondoption'}]
         email_address = self.subscriber.add(
             self.list_id, "subscriber@example.com", "Subscriber", custom_fields, True, "Yes")
-        self.assertEquals(email_address, "subscriber@example.com")
+        self.assertEqual(email_address, "subscriber@example.com")
 
     def test_update_with_custom_fields(self):
         new_email = "new_email_address@example.com"
@@ -87,7 +87,7 @@ class SubscriberTestCase(object):
                                      (self.list_id, quote(self.subscriber.email_address)), None)
         custom_fields = [{"Key": 'website', "Value": 'http://example.com/'}]
         self.subscriber.update(new_email, "Subscriber", custom_fields, True, "Yes")
-        self.assertEquals(self.subscriber.email_address, new_email)
+        self.assertEqual(self.subscriber.email_address, new_email)
 
     def test_update_with_custom_fields_including_clear_option(self):
         new_email = "new_email_address@example.com"
@@ -96,7 +96,7 @@ class SubscriberTestCase(object):
         custom_fields = [
             {"Key": 'website', "Value": 'http://example.com/', "Clear": True}]
         self.subscriber.update(new_email, "Subscriber", custom_fields, True, "No")
-        self.assertEquals(self.subscriber.email_address, new_email)
+        self.assertEqual(self.subscriber.email_address, new_email)
 
     def test_import_subscribers(self):
         self.subscriber.stub_request(
@@ -108,11 +108,11 @@ class SubscriberTestCase(object):
         ]
         import_result = self.subscriber.import_subscribers(
             self.list_id, subscribers, True)
-        self.assertEquals(len(import_result.FailureDetails), 0)
-        self.assertEquals(import_result.TotalUniqueEmailsSubmitted, 3)
-        self.assertEquals(import_result.TotalExistingSubscribers, 0)
-        self.assertEquals(import_result.TotalNewSubscribers, 3)
-        self.assertEquals(len(import_result.DuplicateEmailsInSubmission), 0)
+        self.assertEqual(len(import_result.FailureDetails), 0)
+        self.assertEqual(import_result.TotalUniqueEmailsSubmitted, 3)
+        self.assertEqual(import_result.TotalExistingSubscribers, 0)
+        self.assertEqual(import_result.TotalNewSubscribers, 3)
+        self.assertEqual(len(import_result.DuplicateEmailsInSubmission), 0)
 
     def test_import_subscribers_start_subscription_autoresponders(self):
         self.subscriber.stub_request(
@@ -124,11 +124,11 @@ class SubscriberTestCase(object):
         ]
         import_result = self.subscriber.import_subscribers(
             self.list_id, subscribers, True, True)
-        self.assertEquals(len(import_result.FailureDetails), 0)
-        self.assertEquals(import_result.TotalUniqueEmailsSubmitted, 3)
-        self.assertEquals(import_result.TotalExistingSubscribers, 0)
-        self.assertEquals(import_result.TotalNewSubscribers, 3)
-        self.assertEquals(len(import_result.DuplicateEmailsInSubmission), 0)
+        self.assertEqual(len(import_result.FailureDetails), 0)
+        self.assertEqual(import_result.TotalUniqueEmailsSubmitted, 3)
+        self.assertEqual(import_result.TotalExistingSubscribers, 0)
+        self.assertEqual(import_result.TotalNewSubscribers, 3)
+        self.assertEqual(len(import_result.DuplicateEmailsInSubmission), 0)
 
     def test_import_subscribers_with_custom_fields_including_clear_option(self):
         self.subscriber.stub_request(
@@ -143,11 +143,11 @@ class SubscriberTestCase(object):
         ]
         import_result = self.subscriber.import_subscribers(
             self.list_id, subscribers, True)
-        self.assertEquals(len(import_result.FailureDetails), 0)
-        self.assertEquals(import_result.TotalUniqueEmailsSubmitted, 3)
-        self.assertEquals(import_result.TotalExistingSubscribers, 0)
-        self.assertEquals(import_result.TotalNewSubscribers, 3)
-        self.assertEquals(len(import_result.DuplicateEmailsInSubmission), 0)
+        self.assertEqual(len(import_result.FailureDetails), 0)
+        self.assertEqual(import_result.TotalUniqueEmailsSubmitted, 3)
+        self.assertEqual(import_result.TotalExistingSubscribers, 0)
+        self.assertEqual(import_result.TotalNewSubscribers, 3)
+        self.assertEqual(len(import_result.DuplicateEmailsInSubmission), 0)
 
     def test_import_subscribers_partial_success(self):
         # Stub request with 400 Bad Request as the expected response status
@@ -160,16 +160,16 @@ class SubscriberTestCase(object):
         ]
         import_result = self.subscriber.import_subscribers(
             self.list_id, subscribers, True)
-        self.assertEquals(len(import_result.FailureDetails), 1)
-        self.assertEquals(import_result.FailureDetails[
+        self.assertEqual(len(import_result.FailureDetails), 1)
+        self.assertEqual(import_result.FailureDetails[
                           0].EmailAddress, "example+1@example")
-        self.assertEquals(import_result.FailureDetails[0].Code, 1)
-        self.assertEquals(import_result.FailureDetails[
+        self.assertEqual(import_result.FailureDetails[0].Code, 1)
+        self.assertEqual(import_result.FailureDetails[
                           0].Message, "Invalid Email Address")
-        self.assertEquals(import_result.TotalUniqueEmailsSubmitted, 3)
-        self.assertEquals(import_result.TotalExistingSubscribers, 2)
-        self.assertEquals(import_result.TotalNewSubscribers, 0)
-        self.assertEquals(len(import_result.DuplicateEmailsInSubmission), 0)
+        self.assertEqual(import_result.TotalUniqueEmailsSubmitted, 3)
+        self.assertEqual(import_result.TotalExistingSubscribers, 2)
+        self.assertEqual(import_result.TotalNewSubscribers, 0)
+        self.assertEqual(len(import_result.DuplicateEmailsInSubmission), 0)
 
     def test_import_subscribers_complete_failure_because_of_bad_request(self):
         # Stub request with 400 Bad Request as the expected response status
@@ -189,18 +189,18 @@ class SubscriberTestCase(object):
         self.subscriber.unsubscribe()
 
     def test_history(self):
-        self.subscriber.stub_request("subscribers/%s/history.json?email=%s" % (
+        self.subscriber.stub_request("subscribers/{}/history.json?email={}".format(
             self.list_id, quote(self.subscriber.email_address)), "subscriber_history.json")
         history = self.subscriber.history()
-        self.assertEquals(len(history), 1)
-        self.assertEquals(history[0].Name, "Campaign One")
-        self.assertEquals(history[0].Type, "Campaign")
-        self.assertEquals(history[0].ID, "fc0ce7105baeaf97f47c99be31d02a91")
-        self.assertEquals(len(history[0].Actions), 6)
-        self.assertEquals(history[0].Actions[0].Event, "Open")
-        self.assertEquals(history[0].Actions[0].Date, "2010-10-12 13:18:00")
-        self.assertEquals(history[0].Actions[0].IPAddress, "192.168.126.87")
-        self.assertEquals(history[0].Actions[0].Detail, "")
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0].Name, "Campaign One")
+        self.assertEqual(history[0].Type, "Campaign")
+        self.assertEqual(history[0].ID, "fc0ce7105baeaf97f47c99be31d02a91")
+        self.assertEqual(len(history[0].Actions), 6)
+        self.assertEqual(history[0].Actions[0].Event, "Open")
+        self.assertEqual(history[0].Actions[0].Date, "2010-10-12 13:18:00")
+        self.assertEqual(history[0].Actions[0].IPAddress, "192.168.126.87")
+        self.assertEqual(history[0].Actions[0].Detail, "")
 
     def test_delete(self):
         self.subscriber.stub_request("subscribers/%s.json?email=%s" %

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -3,7 +3,7 @@ import unittest
 from createsend.template import Template
 
 
-class TemplateTestCase(object):
+class TemplateTestCase:
 
     def test_create(self):
         client_id = '87y8d7qyw8d7yq8w7ydwqwd'
@@ -11,18 +11,18 @@ class TemplateTestCase(object):
         t.stub_request("templates/%s.json" % client_id, "create_template.json")
         template_id = t.create(client_id, "Template One", "http://templates.org/index.html",
                                "http://templates.org/files.zip")
-        self.assertEquals(template_id, "98y2e98y289dh89h9383891234")
-        self.assertEquals(t.template_id, "98y2e98y289dh89h9383891234")
+        self.assertEqual(template_id, "98y2e98y289dh89h9383891234")
+        self.assertEqual(t.template_id, "98y2e98y289dh89h9383891234")
 
     def test_details(self):
         self.template.stub_request(
             "templates/%s.json" % self.template.template_id, "template_details.json")
         t = self.template.details()
-        self.assertEquals(t.TemplateID, "98y2e98y289dh89h938389")
-        self.assertEquals(t.Name, "Template One")
-        self.assertEquals(
+        self.assertEqual(t.TemplateID, "98y2e98y289dh89h938389")
+        self.assertEqual(t.Name, "Template One")
+        self.assertEqual(
             t.PreviewURL, "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753")
-        self.assertEquals(
+        self.assertEqual(
             t.ScreenshotURL, "http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600")
 
     def test_update(self):

--- a/test/test_transactional.py
+++ b/test/test_transactional.py
@@ -3,7 +3,7 @@ import unittest
 from createsend.transactional import Transactional
 
 
-class TransactionalTestCase(object):
+class TransactionalTestCase:
 
     def test_smart_email_list(self):
         status = "all"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@
 # and then run "tox" from this directory.
 
 [tox]
-# pip is broken on py32
 envlist = py36, py37, py38, py39, py310, py311, py312, py313
 
 [testenv]


### PR DESCRIPTION
I've ran `pyupgrade --py36-plus` on the project. This has tidied up a few things:

- removed the old Python 2 headers
- Removed `six` requirement
- Use modern string concatenation
- Use python 3 super methods
- Update unit test methods
- I've also removed the recently added fallback for `SSLContext.wrap_socket()` as it is available in [Python 3.6](https://documentation.help/Python-3.6.3/ssl.html#ssl.SSLContext.wrap_socket).

This fixes #80