### PR TITLE
Tidy up SSL connection to fix deprecation warnings

### DIFF
--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -81,30 +81,20 @@ class VerifiedHTTPSConnection(HTTPSConnection):
 
     def connect(self):
         self.connection_kwargs = {}
-        # for > py2.5
-        if hasattr(self, 'timeout'):
-            self.connection_kwargs.update(timeout=self.timeout)
-
-        # for >= py2.7
-        if hasattr(self, 'source_address'):
-            self.connection_kwargs.update(source_address=self.source_address)
+        self.connection_kwargs.update(timeout=self.timeout)
+        self.connection_kwargs.update(source_address=self.source_address)
 
         sock = socket.create_connection(
             (self.host, self.port), **self.connection_kwargs)
 
-        # for >= py2.7
-        if getattr(self, '_tunnel_host', None):
-            self.sock = sock
-            self._tunnel()
-
         cert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
-        context = ssl.SSLContext()
+        context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
         context.verify_mode = ssl.CERT_REQUIRED
         context.load_verify_locations(cert_path)
         if hasattr(self, 'cert_file') and hasattr(self, 'key_file') and self.cert_file and self.key_file:
             context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
-        self.sock = context.wrap_socket(sock)
+        self.sock = context.wrap_socket(sock, server_hostname=self.host)
 
         try:
             match_hostname(self.sock.getpeercert(), self.host)

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -87,6 +87,9 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         sock = socket.create_connection(
             (self.host, self.port), **self.connection_kwargs)
 
+        if self._tunnel_host:
+            self._tunnel()
+
         cert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
         context = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)


### PR DESCRIPTION
Removes some python 2 checks and fixes deprecation warnings on python 3.10 and above. Fixes #85

I feel the `VerifiedHTTPSConnection` class should probably be dropped in favour of using [urllib3.connection.HTTPSConnection](https://urllib3.readthedocs.io/en/stable/reference/urllib3.connection.html#urllib3.connection.HTTPSConnection) as a dependency - the code in this repository appears to be based on a much earlier version of this class. I don't think it is quite a drop in replacement as we'd need to set the CA file included in this repository.