### PR TITLE
Issue #70 improve error output

### DIFF
--- a/lib/createsend/createsend.py
+++ b/lib/createsend/createsend.py
@@ -229,9 +229,11 @@ class CreateSendBase:
         elif status == 404:
             raise NotFound()
         elif status in range(400, 500):
-            raise ClientError()
+              json_data = json_to_py(data)
+              raise ClientError(f"Code: {json_data.Code} {json_data.Message}")
         elif status in range(500, 600):
-            raise ServerError()
+            json_data = json_to_py(data)
+            raise ServerError(f"Code: {json_data.Code} {json_data.Message}")
         return data
 
     def _get(self, path, params={}, username=None, password=None):

--- a/lib/createsend/utils.py
+++ b/lib/createsend/utils.py
@@ -107,8 +107,9 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             raise
 
 
-def json_to_py(j):
-    o = json.loads(j.decode('utf-8'))
+def json_to_py(o):
+    if isinstance(o,bytes):
+        o = json.loads(o.decode('utf-8'))
     if isinstance(o, dict):
         return dict_to_object(o)
     else:

--- a/test/fixtures/sample_client_error.json
+++ b/test/fixtures/sample_client_error.json
@@ -1,0 +1,4 @@
+{
+  "Code": 418,
+  "Message": " I'm a teapot"
+}

--- a/test/fixtures/sample_server_error.json
+++ b/test/fixtures/sample_server_error.json
@@ -1,0 +1,4 @@
+{
+  "Code": 500,
+  "Message": "Internal Server Error"
+}

--- a/test/test_createsend.py
+++ b/test/test_createsend.py
@@ -147,11 +147,11 @@ class CreateSendTestCase:
         self.assertRaises(self.error_responses[404], self.cs.countries)
 
     def test_other_client_error_on_get(self):
-        self.cs.stub_request('countries.json', None, status=418)
+        self.cs.stub_request('countries.json', 'sample_client_error.json', status=418)
         self.assertRaises(self.error_responses[418], self.cs.countries)
 
     def test_server_error_on_get(self):
-        self.cs.stub_request('countries.json', None, status=500)
+        self.cs.stub_request('countries.json', 'sample_server_error.json', status=500)
         self.assertRaises(self.error_responses[500], self.cs.countries)
 
     def test_bad_request_on_post(self):
@@ -176,13 +176,13 @@ class CreateSendTestCase:
 
     def test_other_client_error_on_post(self):
         client = Client(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
-        client.stub_request('clients.json', None, status=418)
+        client.stub_request('clients.json', 'sample_client_error.json', status=418)
         self.assertRaises(self.error_responses[418], client.create, "Client Company Name",
                           "(GMT+10:00) Canberra, Melbourne, Sydney", "Australia")
 
     def test_server_error_on_post(self):
         client = Client(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
-        client.stub_request('clients.json', None, status=500)
+        client.stub_request('clients.json', 'sample_server_error.json', status=500)
         self.assertRaises(self.error_responses[500], client.create, "Client Company Name",
                           "(GMT+10:00) Canberra, Melbourne, Sydney", "Australia")
 
@@ -210,14 +210,14 @@ class CreateSendTestCase:
     def test_other_client_error_on_put(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
-            'templates/uhiuhiuhiuhiuhiuhiuh.json', None, status=418)
+            'templates/uhiuhiuhiuhiuhiuhiuh.json', 'sample_client_error.json', status=418)
         self.assertRaises(self.error_responses[418], template.update, "Template One Updated", "http://templates.org/index.html",
                           "http://templates.org/files.zip")
 
     def test_server_error_on_put(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
-            'templates/uhiuhiuhiuhiuhiuhiuh.json', None, status=500)
+            'templates/uhiuhiuhiuhiuhiuhiuh.json', 'sample_server_error.json', status=500)
         self.assertRaises(self.error_responses[500], template.update, "Template One Updated", "http://templates.org/index.html",
                           "http://templates.org/files.zip")
 
@@ -242,13 +242,13 @@ class CreateSendTestCase:
     def test_other_client_error_on_delete(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
-            'templates/uhiuhiuhiuhiuhiuhiuh.json', None, status=418)
+            'templates/uhiuhiuhiuhiuhiuhiuh.json', 'sample_client_error.json', status=418)
         self.assertRaises(self.error_responses[418], template.delete)
 
     def test_server_error_on_delete(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
-            'templates/uhiuhiuhiuhiuhiuhiuh.json', None, status=500)
+            'templates/uhiuhiuhiuhiuhiuhiuh.json', 'sample_server_error.json', status=500)
         self.assertRaises(self.error_responses[500], template.delete)
 
 


### PR DESCRIPTION
This PR  now causes 400 and 500 errors to print their codes and message. To address https://github.com/campaignmonitor/createsend-python/issues/70



# Before
![Before](https://github.com/user-attachments/assets/1e3927b1-a1f9-453c-a5a4-9875cd54da1d)


# After
![After](https://github.com/user-attachments/assets/d09961fd-2d59-4486-9e27-38b9592555cd)
