### PR TITLE
Add subscriber SMS functionality

### DIFF
--- a/lib/createsend/subscriber.py
+++ b/lib/createsend/subscriber.py
@@ -22,7 +22,7 @@ class Subscriber(CreateSendBase):
                              (list_id or self.list_id), params=params)
         return json_to_py(response)
 
-    def add(self, list_id, email_address, name, custom_fields, resubscribe, consent_to_track, restart_subscription_based_autoresponders=False):
+    def add(self, list_id, email_address, name, custom_fields, resubscribe, consent_to_track, restart_subscription_based_autoresponders=False, mobile_number=False, consent_to_track_sms="Unchanged"):
         """Adds a subscriber to a subscriber list."""
         validate_consent_to_track(consent_to_track)
         body = {
@@ -32,11 +32,16 @@ class Subscriber(CreateSendBase):
             "Resubscribe": resubscribe,
             "ConsentToTrack": consent_to_track,
             "RestartSubscriptionBasedAutoresponders": restart_subscription_based_autoresponders}
+
+        if mobile_number:
+            body["MobileNumber"] = mobile_number
+            body["ConsentToSendSms"] = consent_to_track_sms
+            
         response = self._post("/subscribers/%s.json" %
                               list_id, json.dumps(body))
         return json_to_py(response)
 
-    def update(self, new_email_address, name, custom_fields, resubscribe, consent_to_track, restart_subscription_based_autoresponders=False):
+    def update(self, new_email_address, name, custom_fields, resubscribe, consent_to_track, restart_subscription_based_autoresponders=False, mobile_number=False, consent_to_track_sms="Unchanged"):
         """Updates any aspect of a subscriber, including email address, name, and
         custom field data if supplied."""
         validate_consent_to_track(consent_to_track)
@@ -48,6 +53,11 @@ class Subscriber(CreateSendBase):
             "Resubscribe": resubscribe,
             "ConsentToTrack": consent_to_track,
             "RestartSubscriptionBasedAutoresponders": restart_subscription_based_autoresponders}
+        
+        if mobile_number:
+            body["MobileNumber"] = mobile_number
+            body["ConsentToSendSms"] = consent_to_track_sms
+            
         response = self._put("/subscribers/%s.json" % self.list_id,
                              body=json.dumps(body), params=params)
         # Update self.email_address, so this object can continue to be used

--- a/lib/createsend/subscriber.py
+++ b/lib/createsend/subscriber.py
@@ -35,6 +35,7 @@ class Subscriber(CreateSendBase):
 
         if mobile_number:
             body["MobileNumber"] = mobile_number
+            validate_consent_to_track(consent_to_track_sms)
             body["ConsentToSendSms"] = consent_to_track_sms
             
         response = self._post("/subscribers/%s.json" %
@@ -56,6 +57,7 @@ class Subscriber(CreateSendBase):
         
         if mobile_number:
             body["MobileNumber"] = mobile_number
+            validate_consent_to_track(consent_to_track_sms)
             body["ConsentToSendSms"] = consent_to_track_sms
             
         response = self._put("/subscribers/%s.json" % self.list_id,

--- a/samples/subscribers.py
+++ b/samples/subscribers.py
@@ -6,9 +6,29 @@ auth = {
 listId = 'YOUR_LIST_ID'
 emailAddress = 'YOUR_SUBSCRIBER_EMAIL_ADDRESS'
 
+subscriberName = "YOUR_SUBSCRIBER_NAME"
+subscriberCustomFields = []
+subscriberResubscribed = False
+subscriberConsentToTrack = 'Unchanged'
+subscriberMobileNumber = "+61491570006" # This is a reserved mobile number by the Australian Communications and Media Authority
+subscriberConsentToSendSms = "Yes"
+
 subscriber = Subscriber(auth, listId, emailAddress)
 
 # Get the details for a subscriber
 subscriberDetail = subscriber.get()
 for property, value in vars(subscriberDetail).items():
   print(property, ":", value)
+  
+# Adding a subscriber
+  #This implemntation defaults the value of 'restart_subscription_based_autoresponders' to false
+subscriber.add(listId, emailAddress, subscriberName, subscriberCustomFields, subscriberResubscribed, subscriberConsentToTrack)
+
+# Adding a subscriber with a mobile number
+  #This implemntation defaults the value of 'restart_subscription_based_autoresponders' to false
+  #This also sets the default value of 'consent_to_track_sms' to 'unchanged', meaning new users will not receive SMS communications by default."
+subscriber.add(listId, emailAddress, subscriberName, subscriberCustomFields, subscriberConsentToTrack, mobile_Number=subscriberMobileNumber)
+
+#Alternative to set SMS tracking permissions 
+  # This implemntation defaults the value of 'restart_subscription_based_autoresponders' to false
+subscriber.add(listId, emailAddress, subscriberName, subscriberCustomFields, subscriberConsentToTrack, mobile_Number=subscriberMobileNumber, consent_to_track_sms=subscriberConsentToSendSms)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="createsend",
-    version='9.0.2',
+    version='9.1.2',
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',


### PR DESCRIPTION
This PR allows users to add subscribers' mobile numbers and permission to send them to SMS when adding or updating subscriber information.