### PR TITLE
Use HTTPS for documentation and test fixture URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Guidelines for contributing
 
-1. [Fork the repository](https://help.github.com/articles/fork-a-repo).
-2. [Create a topic branch](http://learn.github.com/p/branching.html).
+1. [Fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+2. [Create a topic branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 3. Make your changes, including tests for your changes which maintain [coverage](https://coveralls.io/r/campaignmonitor/createsend-python).
 4. Ensure that all tests pass, by running `rake`.
 5. It should go without saying, but do not increment the version number in your commits.
-6. [Submit a pull request](https://help.github.com/articles/using-pull-requests).
+6. [Submit a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -172,7 +172,7 @@
 
 ## v3.1.0 - 15 Apr, 2013
 
-* Added support for [single sign on](http://www.campaignmonitor.com/api/account/#single_sign_on) which allows initiation of external login sessions to Campaign Monitor.
+* Added support for [single sign on](https://www.campaignmonitor.com/api/account/#single_sign_on) which allows initiation of external login sessions to Campaign Monitor.
 
 ## v3.0.0 - 25 Mar, 2013
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # createsend-python history
 
+## v9.1.3 - 4 Feb, 2025
+* Updated cacert.pem. From [#92](https://github.com/campaignmonitor/createsend-python/pull/92) 
+* Updates various URLs to use HTTPS
+* Fixes some URLs in CONTRIBUTING.md
+* Use GH Workflow badge instead of inactive Travis one in documentation. From [#91](https://github.com/campaignmonitor/createsend-python/pull/91)
+
+
+## v9.1.2 - 29 Jan, 2025
+* This release updates the add() and update() methods in lib/subscriber.py, enabling users to add subscribers' mobile numbers along with their consent to receive SMS messages.
+* Updated subscriber.py within samples to showcase new use cases resulting from these updates. [PR](https://github.com/campaignmonitor/createsend-python/pull/90)
+
 ## v9.0.2 - 23 Jan, 2025
 * Improved error handling for 400 and 500 errors: Now displays error codes and error messages for better debugging.
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ Please check the [instructions for releasing](https://github.com/campaignmonitor
 
 ## This stuff should be green
 
-[![Build Status](https://secure.travis-ci.org/campaignmonitor/createsend-python.png)][travis] [![Coverage Status](https://coveralls.io/repos/campaignmonitor/createsend-python/badge.png?branch=master)][coveralls]
+[![Python tests](https://github.com/campaignmonitor/createsend-python/actions/workflows/tests.yml/badge.svg)](https://github.com/campaignmonitor/createsend-python/actions/workflows/tests.yml) [![Coverage Status](https://coveralls.io/repos/campaignmonitor/createsend-python/badge.png?branch=master)][coveralls]
 
-[travis]: http://travis-ci.org/campaignmonitor/createsend-python
 [coveralls]: https://coveralls.io/r/campaignmonitor/createsend-python

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # createsend
 
-A Python library which implements the complete functionality of the [Campaign Monitor API](http://www.campaignmonitor.com/api/). Requires Python 3.8 or above.
+A Python library which implements the complete functionality of the [Campaign Monitor API](https://www.campaignmonitor.com/api/). Requires Python 3.8 or above.
 
 ## Installation
 
@@ -14,9 +14,9 @@ The Campaign Monitor API supports authentication using either OAuth or an API ke
 
 ### Using OAuth
 
-Depending on the environment you are developing in, you may wish to use a Python OAuth library to get access tokens for your users. If you use [Flask](http://flask.pocoo.org/), you may like to refer to this [example application](https://gist.github.com/jdennes/4754097), which uses the [Flask-OAuth](http://pythonhosted.org/Flask-OAuth/) package to authenticate.
+Depending on the environment you are developing in, you may wish to use a Python OAuth library to get access tokens for your users. If you use [Flask](https://flask.palletsprojects.com/en/stable/), you may like to refer to this [example application](https://gist.github.com/jdennes/4754097), which uses the [Flask-OAuth](https://pythonhosted.org/Flask-OAuth/) package to authenticate.
 
-If you don't use an OAuth library, you will need to manually get access tokens for your users by following the instructions included in the Campaign Monitor API [documentation](http://www.campaignmonitor.com/api/getting-started/#authenticating_with_oauth). This package provides functionality to help you do this, as described below. There's also another Flask [example application](https://gist.github.com/jdennes/4761254) you may wish to reference, which doesn't depend on any OAuth libraries.
+If you don't use an OAuth library, you will need to manually get access tokens for your users by following the instructions included in the Campaign Monitor API [documentation](https://www.campaignmonitor.com/api/v3-3/getting-started/#authentication). This package provides functionality to help you do this, as described below. There's also another Flask [example application](https://gist.github.com/jdennes/4761254) you may wish to reference, which doesn't depend on any OAuth libraries.
 
 The first thing your application should do is redirect your user to the Campaign Monitor authorization URL where they will have the opportunity to approve your application to access their Campaign Monitor account. You can get this authorization URL by using the `authorize_url()` function, like so:
 
@@ -204,7 +204,7 @@ For example, if you wanted to find out how to call the `Subscriber.add()` method
 ```python
 def test_add_with_custom_fields(self):
   self.subscriber.stub_request("subscribers/%s.json" % self.list_id, "add_subscriber.json")
-  custom_fields = [ { "Key": 'website', "Value": 'http://example.com/' } ]
+  custom_fields = [ { "Key": 'website', "Value": 'https://example.com/' } ]
   email_address = self.subscriber.add(self.list_id, "subscriber@example.com", "Subscriber", custom_fields, True)
   self.assertEqual(email_address, "subscriber@example.com")
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ pip install setuptools
   git push origin master --tags
   ```
 
-- Ensure that all [tests](https://travis-ci.org/campaignmonitor/createsend-python) pass, and that [coverage](https://coveralls.io/r/campaignmonitor/createsend-python) is maintained or improved.
+- Ensure that all [tests](https://github.com/campaignmonitor/createsend-python/actions/workflows/tests.yml) pass, and that [coverage](https://coveralls.io/r/campaignmonitor/createsend-python) is maintained or improved.
 
 - Add a new [GitHub Release](https://github.com/campaignmonitor/createsend-python/releases) using the newly created tag.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@ pip install setuptools
 
 ## Prepare the release
 
-- Increment `version` in the `setup.py` file, ensuring that you use [Semantic Versioning](http://semver.org/).
+- Increment `version` in the `setup.py` file, ensuring that you use [Semantic Versioning](https://semver.org/).
 - Add an entry to `HISTORY.md` which clearly explains the new release.
 - Commit your changes:
 

--- a/lib/createsend/createsend.py
+++ b/lib/createsend/createsend.py
@@ -312,7 +312,7 @@ class CreateSend(CreateSendBase):
         """
         Get a URL which initiates a new external session for the user with the
         given email.
-        Full details: http://www.campaignmonitor.com/api/account/#single_sign_on
+        Full details: https://www.campaignmonitor.com/api/account/#single_sign_on
 
         :param email: String The representing the email address of the
           Campaign Monitor user for whom the login session should be created.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     description="A library which implements the complete functionality of the Campaign Monitor API.",
     author='Campaign Monitor',
     author_email='support@campaignmonitor.com',
-    url="http://campaignmonitor.github.io/createsend-python/",
+    url="https://campaignmonitor.github.io/createsend-python/",
     license="MIT",
     keywords="createsend campaign monitor email",
     packages=find_packages('lib'),

--- a/test/fixtures/active_subscribers.json
+++ b/test/fixtures/active_subscribers.json
@@ -9,7 +9,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://example.com"
+          "Value": "https://example.com"
         },
         {
           "Key": "multi select field",
@@ -39,7 +39,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://subdomain.example.com"
+          "Value": "https://subdomain.example.com"
         }
       ],
       "ReadsEmailWith": "Gmail"
@@ -53,7 +53,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://subdomain.example.com"
+          "Value": "https://subdomain.example.com"
         }
       ],
       "ReadsEmailWith": ""

--- a/test/fixtures/active_subscribers_with_tracking_preference.json
+++ b/test/fixtures/active_subscribers_with_tracking_preference.json
@@ -9,7 +9,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://example.com"
+          "Value": "https://example.com"
         },
         {
           "Key": "multi select field",
@@ -40,7 +40,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://subdomain.example.com"
+          "Value": "https://subdomain.example.com"
         }
       ],
       "ReadsEmailWith": "Gmail",
@@ -55,7 +55,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://subdomain.example.com"
+          "Value": "https://subdomain.example.com"
         }
       ],
       "ReadsEmailWith": "",

--- a/test/fixtures/campaign_clicks.json
+++ b/test/fixtures/campaign_clicks.json
@@ -2,7 +2,7 @@
   "Results": [
     {
       "EmailAddress": "subs+6576576576@example.com",
-      "URL": "http://video.google.com.au/?hl=en&tab=wv",
+      "URL": "https://video.google.com.au/?hl=en&tab=wv",
       "ListID": "512a3bc577a58fdf689c654329b50fa0",
       "Date": "2010-10-11 08:29:00",
       "IPAddress": "192.168.126.87",
@@ -15,7 +15,7 @@
     },
     {
       "EmailAddress": "subs+6576576576@example.com",
-      "URL": "http://mail.google.com/mail/?hl=en&tab=wm",
+      "URL": "https://mail.google.com/mail/?hl=en&tab=wm",
       "ListID": "512a3bc577a58fdf689c654329b50fa0",
       "Date": "2010-10-11 08:29:00",
       "IPAddress": "192.168.126.87",
@@ -28,7 +28,7 @@
     },
     {
       "EmailAddress": "subs+6576576576@example.com",
-      "URL": "http://mail.google.com/mail/?hl=en&tab=wm",
+      "URL": "https://mail.google.com/mail/?hl=en&tab=wm",
       "ListID": "512a3bc577a58fdf689c654329b50fa0",
       "Date": "2010-10-06 17:24:00",
       "IPAddress": "192.168.126.87",

--- a/test/fixtures/campaign_summary.json
+++ b/test/fixtures/campaign_summary.json
@@ -9,8 +9,8 @@
   "Mentions": 23,
   "Forwards": 11,
   "Likes": 32,
-  "WebVersionURL": "http://createsend.com/t/r-3A433FC72FFE3B8B",
-  "WebVersionTextURL": "http://createsend.com/t/r-3A433FC72FFE3B8B/t",
-  "WorldviewURL": "http://client.createsend.com/reports/wv/r/3A433FC72FFE3B8B",
+  "WebVersionURL": "https://createsend.com/t/r-3A433FC72FFE3B8B",
+  "WebVersionTextURL": "https://createsend.com/t/r-3A433FC72FFE3B8B/t",
+  "WorldviewURL": "https://client.createsend.com/reports/wv/r/3A433FC72FFE3B8B",
   "SpamComplaints": 23
 }

--- a/test/fixtures/campaigns.json
+++ b/test/fixtures/campaigns.json
@@ -1,8 +1,8 @@
 {
     "Results": [
       {
-        "WebVersionURL": "http://createsend.com/t/r-765E86829575EE2C",
-        "WebVersionTextURL": "http://createsend.com/t/r-765E86829575EE2C/t",
+        "WebVersionURL": "https://createsend.com/t/r-765E86829575EE2C",
+        "WebVersionTextURL": "https://createsend.com/t/r-765E86829575EE2C/t",
         "CampaignID": "fc0ce7105baeaf97f47c99be31d02a91",
         "Subject": "Campaign One",
         "Name": "Campaign One",
@@ -14,8 +14,8 @@
         "Tags": ["Tag1", "Tag2"]
       },
       {
-        "WebVersionURL": "http://createsend.com/t/r-DD543566A87C9B8B",
-        "WebVersionTextURL": "http://createsend.com/t/r-DD543566A87C9B8B/t",
+        "WebVersionURL": "https://createsend.com/t/r-DD543566A87C9B8B",
+        "WebVersionTextURL": "https://createsend.com/t/r-DD543566A87C9B8B/t",
         "CampaignID": "072472b88c853ae5dedaeaf549a8d607",
         "Subject": "Campaign Two",
         "Name": "Campaign Two",

--- a/test/fixtures/deleted_subscribers.json
+++ b/test/fixtures/deleted_subscribers.json
@@ -18,7 +18,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://google.com"
+          "Value": "https://google.com"
         }
       ],
       "ReadsEmailWith": "Gmail"

--- a/test/fixtures/drafts.json
+++ b/test/fixtures/drafts.json
@@ -7,8 +7,8 @@
     "FromEmail": "myemail@example.com",
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
-    "PreviewURL": "http://createsend.com/t/r-E97A7BB2E6983DA1",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "PreviewURL": "https://createsend.com/t/r-E97A7BB2E6983DA1",
+    "PreviewTextURL": "https://createsend.com/t/r-E97A7BB2E6983DA1/t",
     "Tags": ["Tags5"]
   },
   {
@@ -19,8 +19,8 @@
     "FromEmail": "myemail@example.com",
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2010-08-19 16:08:00",
-    "PreviewURL": "http://createsend.com/t/r-E97A7BB2E6983DA1",
-    "PreviewTextURL": "http://createsend.com/t/r-E97A7BB2E6983DA1/t",
+    "PreviewURL": "https://createsend.com/t/r-E97A7BB2E6983DA1",
+    "PreviewTextURL": "https://createsend.com/t/r-E97A7BB2E6983DA1/t",
     "Tags": []
   }
 ]

--- a/test/fixtures/journey_email_clicks_no_params.json
+++ b/test/fixtures/journey_email_clicks_no_params.json
@@ -3,7 +3,7 @@
     {
       "EmailAddress": "asdf@example.com",
       "Date": "2019-08-19 10:23:00",
-      "URL": "http://mail.google.com/mail/?hl=en&tab=wm",
+      "URL": "https://mail.google.com/mail/?hl=en&tab=wm",
       "IPAddress": "198.148.196.144",
       "Latitude": -33.8591,
       "Longitude": 151.200195,

--- a/test/fixtures/journey_email_clicks_with_params.json
+++ b/test/fixtures/journey_email_clicks_with_params.json
@@ -15,7 +15,7 @@
     {
       "EmailAddress": "asdf@example.com",
       "Date": "2019-08-19 10:23:00",
-      "URL": "http://mail.google.com/mail/?hl=en&tab=wm",
+      "URL": "https://mail.google.com/mail/?hl=en&tab=wm",
       "IPAddress": "198.148.196.144",
       "Latitude": -33.8591,
       "Longitude": 151.200195,

--- a/test/fixtures/list_webhooks.json
+++ b/test/fixtures/list_webhooks.json
@@ -2,7 +2,7 @@
   {
     "WebhookID": "943678317049bc13",
     "Events": [ "Deactivate" ],
-    "Url": "http://www.postbin.org/d9w8ud9wud9w",
+    "Url": "https://www.postbin.org/d9w8ud9wud9w",
     "Status": "Active",
     "PayloadFormat": "Json"
   },
@@ -11,7 +11,7 @@
     "Events": [
       "Subscribe"
     ],
-    "Url": "http://www.postbin.org/hiuhiu2h2u",
+    "Url": "https://www.postbin.org/hiuhiu2h2u",
     "Status": "Active",
     "PayloadFormat": "Xml"
   }

--- a/test/fixtures/scheduled_campaigns.json
+++ b/test/fixtures/scheduled_campaigns.json
@@ -9,8 +9,8 @@
     "FromEmail": "myemail@example.com",
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:37:00",
-    "PreviewURL": "http://createsend.com/t/r-DD543521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD543521A87C9B8B/t",
+    "PreviewURL": "https://createsend.com/t/r-DD543521A87C9B8B",
+    "PreviewTextURL": "https://createsend.com/t/r-DD543521A87C9B8B/t",
     "Tags": []
   },
   {
@@ -23,8 +23,8 @@
     "FromEmail": "myemail@example.com",
     "ReplyTo": "myemail@example.com",
     "DateCreated": "2011-05-24 10:39:00",
-    "PreviewURL": "http://createsend.com/t/r-DD913521A87C9B8B",
-    "PreviewTextURL": "http://createsend.com/t/r-DD913521A87C9B8B/t",
+    "PreviewURL": "https://createsend.com/t/r-DD913521A87C9B8B",
+    "PreviewTextURL": "https://createsend.com/t/r-DD913521A87C9B8B/t",
     "Tags": ["Tags3", "Tags4"]
   }
 ]

--- a/test/fixtures/subscriber_details.json
+++ b/test/fixtures/subscriber_details.json
@@ -7,7 +7,7 @@
   "CustomFields": [
     {
       "Key": "website",
-      "Value": "http://example.com"
+      "Value": "https://example.com"
     },
     {
       "Key": "age",

--- a/test/fixtures/subscriber_details_with_tracking_preference.json
+++ b/test/fixtures/subscriber_details_with_tracking_preference.json
@@ -7,7 +7,7 @@
   "CustomFields": [
     {
       "Key": "website",
-      "Value": "http://example.com"
+      "Value": "https://example.com"
     },
     {
       "Key": "age",

--- a/test/fixtures/subscriber_history.json
+++ b/test/fixtures/subscriber_history.json
@@ -14,13 +14,13 @@
         "Event": "Click",
         "Date": "2010-10-12 13:16:00",
         "IPAddress": "192.168.126.87",
-        "Detail": "http://example.com/post/12323/"
+        "Detail": "https://example.com/post/12323/"
       },
       {
         "Event": "Click",
         "Date": "2010-10-12 13:15:00",
         "IPAddress": "192.168.126.87",
-        "Detail": "http://example.com/post/29889/"
+        "Detail": "https://example.com/post/29889/"
       },
       {
         "Event": "Open",
@@ -32,7 +32,7 @@
         "Event": "Click",
         "Date": "2010-10-12 13:01:00",
         "IPAddress": "192.168.126.87",
-        "Detail": "http://example.com/post/82211/"
+        "Detail": "https://example.com/post/82211/"
       },
       {
         "Event": "Open",

--- a/test/fixtures/template_details.json
+++ b/test/fixtures/template_details.json
@@ -1,6 +1,6 @@
 {
   "TemplateID": "98y2e98y289dh89h938389",
   "Name": "Template One",
-  "PreviewURL": "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753",
-  "ScreenshotURL": "http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600"
+  "PreviewURL": "https://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753",
+  "ScreenshotURL": "https://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600"
 }

--- a/test/fixtures/templates.json
+++ b/test/fixtures/templates.json
@@ -2,13 +2,13 @@
   {
     "TemplateID": "5cac213cf061dd4e008de5a82b7a3621",
     "Name": "Template One",
-    "PreviewURL": "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753",
-    "ScreenshotURL": "http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092541"
+    "PreviewURL": "https://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753",
+    "ScreenshotURL": "https://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092541"
   },
   {
     "TemplateID": "da645c271bc85fb6550acff937c2ab2e",
     "Name": "Template Two",
-    "PreviewURL": "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=C8A180629495E798&d=r&c=E816F55BFAD1A753",
-    "ScreenshotURL": "http://preview.createsend.com/ts/r/18/7B3/552/187B3552.jpg?0705043527"
+    "PreviewURL": "https://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=C8A180629495E798&d=r&c=E816F55BFAD1A753",
+    "ScreenshotURL": "https://preview.createsend.com/ts/r/18/7B3/552/187B3552.jpg?0705043527"
   }
 ]

--- a/test/fixtures/tx_message_details_with_statistics.json
+++ b/test/fixtures/tx_message_details_with_statistics.json
@@ -57,7 +57,7 @@
             "EmailAddress": "jamesmith@example.com",
             "Date": "2009-05-18 16:45:00",
             "IPAddress": "192.168.0.1",
-            "URL": "http://www.myexammple.com/index.html",
+            "URL": "https://www.myexammple.com/index.html",
             "Geolocation": {
               "Latitude": -33.8683,
               "Longitude": 151.2086,

--- a/test/fixtures/unconfirmed_subscribers.json
+++ b/test/fixtures/unconfirmed_subscribers.json
@@ -9,7 +9,7 @@
             "CustomFields": [
                 {
                     "Key": "website",
-                    "Value": "http://example.com"
+                    "Value": "https://example.com"
                 }
             ],
             "ReadsEmailWith": ""
@@ -23,7 +23,7 @@
             "CustomFields": [
                 {
                     "Key": "website",
-                    "Value": "http://subdomain.example.com"
+                    "Value": "https://subdomain.example.com"
                 }
             ],
             "ReadsEmailWith": ""

--- a/test/fixtures/unsubscribed_subscribers.json
+++ b/test/fixtures/unsubscribed_subscribers.json
@@ -18,7 +18,7 @@
       "CustomFields": [
         {
           "Key": "website",
-          "Value": "http://google.com"
+          "Value": "https://google.com"
         }
       ],
       "ReadsEmailWith": "Gmail"

--- a/test/test_authentication.py
+++ b/test/test_authentication.py
@@ -25,7 +25,7 @@ class AuthenticationTestCase(unittest.TestCase):
             state=state
         )
         self.assertEqual(authorize_url,
-                          "https://api.createsend.com/oauth?client_id=8998879&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&scope=ViewReports%2CCreateCampaigns%2CSendCampaigns&state=89879287"
+                          "https://api.createsend.com/oauth?client_id=8998879&redirect_uri=https%3A%2F%2Fexample.com%2Fauth&scope=ViewReports%2CCreateCampaigns%2CSendCampaigns&state=89879287"
                           )
 
     def test_authorize_url_without_state(self):
@@ -40,7 +40,7 @@ class AuthenticationTestCase(unittest.TestCase):
             scope=scope
         )
         self.assertEqual(authorize_url,
-                          "https://api.createsend.com/oauth?client_id=8998879&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&scope=ViewReports%2CCreateCampaigns%2CSendCampaigns"
+                          "https://api.createsend.com/oauth?client_id=8998879&redirect_uri=https%3A%2F%2Fexample.com%2Fauth&scope=ViewReports%2CCreateCampaigns%2CSendCampaigns"
                           )
 
     def test_exchange_token_success(self):
@@ -58,7 +58,7 @@ class AuthenticationTestCase(unittest.TestCase):
             code=code
         )
         self.assertEqual(self.cs.faker.actual_body,
-                          "grant_type=authorization_code&client_id=8998879&client_secret=iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&code=98uqw9d8qu9wdu")
+                          "grant_type=authorization_code&client_id=8998879&client_secret=iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd&redirect_uri=https%3A%2F%2Fexample.com%2Fauth&code=98uqw9d8qu9wdu")
         self.assertEqual(access_token, "SlAV32hkKG")
         self.assertEqual(expires_in, 1209600)
         self.assertEqual(refresh_token, "tGzv3JOkF0XG5Qx2TlKWIA")
@@ -74,7 +74,7 @@ class AuthenticationTestCase(unittest.TestCase):
         self.assertRaises(Exception, self.cs.exchange_token,
                           client_id, client_secret, redirect_uri, code)
         self.assertEqual(self.cs.faker.actual_body,
-                          "grant_type=authorization_code&client_id=8998879&client_secret=iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd&redirect_uri=http%3A%2F%2Fexample.com%2Fauth&code=invalidcode")
+                          "grant_type=authorization_code&client_id=8998879&client_secret=iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd&redirect_uri=https%3A%2F%2Fexample.com%2Fauth&code=invalidcode")
 
     def test_can_authenticate_by_calling_auth_with_api_key(self):
         self.cs = CreateSend(self.api_key_auth_details)

--- a/test/test_authentication.py
+++ b/test/test_authentication.py
@@ -13,7 +13,7 @@ class AuthenticationTestCase(unittest.TestCase):
 
     def test_authorize_url_with_state(self):
         client_id = 8998879
-        redirect_uri = 'http://example.com/auth'
+        redirect_uri = 'https://example.com/auth'
         scope = 'ViewReports,CreateCampaigns,SendCampaigns'
         state = 89879287
 
@@ -30,7 +30,7 @@ class AuthenticationTestCase(unittest.TestCase):
 
     def test_authorize_url_without_state(self):
         client_id = 8998879
-        redirect_uri = 'http://example.com/auth'
+        redirect_uri = 'https://example.com/auth'
         scope = 'ViewReports,CreateCampaigns,SendCampaigns'
 
         self.cs = CreateSend(self.oauth_auth_details)
@@ -46,7 +46,7 @@ class AuthenticationTestCase(unittest.TestCase):
     def test_exchange_token_success(self):
         client_id = 8998879
         client_secret = 'iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd'
-        redirect_uri = 'http://example.com/auth'
+        redirect_uri = 'https://example.com/auth'
         code = '98uqw9d8qu9wdu'
         self.cs = CreateSend(self.oauth_auth_details)
         self.cs.stub_request(
@@ -66,7 +66,7 @@ class AuthenticationTestCase(unittest.TestCase):
     def test_echange_token_failure(self):
         client_id = 8998879
         client_secret = 'iou0q9wud0q9wd0q9wid0q9iwd0q9wid0q9wdqwd'
-        redirect_uri = 'http://example.com/auth'
+        redirect_uri = 'https://example.com/auth'
         code = 'invalidcode'
         self.cs = CreateSend(self.oauth_auth_details)
         self.cs.stub_request(

--- a/test/test_campaign.py
+++ b/test/test_campaign.py
@@ -11,12 +11,12 @@ class CampaignTestCase:
         c = Campaign()
         c.stub_request("campaigns/%s.json" % client_id, "create_campaign.json")
         campaign_id = c.create(client_id, "subject", "name", "g'day", "good.day@example.com", "good.day@example.com",
-                               "http://example.com/campaign.html", "http://example.com/campaign.txt", [
+                               "https://example.com/campaign.html", "https://example.com/campaign.txt", [
                                    '7y12989e82ue98u2e', 'dh9w89q8w98wudwd989'],
                                ['y78q9w8d9w8ud9q8uw', 'djw98quw9duqw98uwd98'])
 
         self.assertEqual(
-            "\"TextUrl\": \"http://example.com/campaign.txt\"" in c.faker.actual_body, True)
+            "\"TextUrl\": \"https://example.com/campaign.txt\"" in c.faker.actual_body, True)
         self.assertEqual(c.campaign_id, "787y87y87y87y87y87y8712341234")
         self.assertEqual(campaign_id, "787y87y87y87y87y87y8712341234")
 
@@ -25,7 +25,7 @@ class CampaignTestCase:
         c = Campaign()
         c.stub_request("campaigns/%s.json" % client_id, "create_campaign.json")
         campaign_id = c.create(client_id, "subject", "name", "g'day", "good.day@example.com", "good.day@example.com",
-                               "http://example.com/campaign.html", None, [
+                               "https://example.com/campaign.html", None, [
                                    '7y12989e82ue98u2e', 'dh9w89q8w98wudwd989'],
                                ['y78q9w8d9w8ud9q8uw', 'djw98quw9duqw98uwd98'])
 
@@ -38,19 +38,19 @@ class CampaignTestCase:
             "Singlelines": [
                 {
                     "Content": "This is a heading",
-                    "Href": "http://example.com/"
+                    "Href": "https://example.com/"
                 }
             ],
             "Multilines": [
                 {
-                    "Content": "<p>This is example</p><p>multiline <a href=\"http://example.com\">content</a>...</p>"
+                    "Content": "<p>This is example</p><p>multiline <a href=\"https://example.com\">content</a>...</p>"
                 }
             ],
             "Images": [
                 {
-                    "Content": "http://example.com/image.png",
+                    "Content": "https://example.com/image.png",
                     "Alt": "This is alt text for an image",
-                    "Href": "http://example.com/"
+                    "Href": "https://example.com/"
                 }
             ],
             "Repeaters": [
@@ -61,19 +61,19 @@ class CampaignTestCase:
                             "Singlelines": [
                                 {
                                     "Content": "This is a repeater heading",
-                                    "Href": "http://example.com/"
+                                    "Href": "https://example.com/"
                                 }
                             ],
                             "Multilines": [
                                 {
-                                    "Content": "<p>This is example</p><p>multiline <a href=\"http://example.com\">content</a>...</p>"
+                                    "Content": "<p>This is example</p><p>multiline <a href=\"https://example.com\">content</a>...</p>"
                                 }
                             ],
                             "Images": [
                                 {
-                                    "Content": "http://example.com/repeater-image.png",
+                                    "Content": "https://example.com/repeater-image.png",
                                     "Alt": "This is alt text for a repeater image",
-                                    "Href": "http://example.com/"
+                                    "Href": "https://example.com/"
                                 }
                             ]
                         }
@@ -156,11 +156,11 @@ class CampaignTestCase:
         self.assertEqual(summary.Forwards, 11)
         self.assertEqual(summary.Likes, 32)
         self.assertEqual(summary.WebVersionURL,
-                          "http://createsend.com/t/r-3A433FC72FFE3B8B")
+                          "https://createsend.com/t/r-3A433FC72FFE3B8B")
         self.assertEqual(summary.WebVersionTextURL,
-                          "http://createsend.com/t/r-3A433FC72FFE3B8B/t")
+                          "https://createsend.com/t/r-3A433FC72FFE3B8B/t")
         self.assertEqual(
-            summary.WorldviewURL, "http://client.createsend.com/reports/wv/r/3A433FC72FFE3B8B")
+            summary.WorldviewURL, "https://client.createsend.com/reports/wv/r/3A433FC72FFE3B8B")
         self.assertEqual(summary.SpamComplaints, 23)
 
     def test_email_client_usage(self):
@@ -240,7 +240,7 @@ class CampaignTestCase:
         self.assertEqual(
             clicks.Results[0].EmailAddress, "subs+6576576576@example.com")
         self.assertEqual(
-            clicks.Results[0].URL, "http://video.google.com.au/?hl=en&tab=wv")
+            clicks.Results[0].URL, "https://video.google.com.au/?hl=en&tab=wv")
         self.assertEqual(
             clicks.Results[0].ListID, "512a3bc577a58fdf689c654329b50fa0")
         self.assertEqual(clicks.Results[0].Date, "2010-10-11 08:29:00")

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -36,9 +36,9 @@ class ClientTestCase:
         self.assertEqual(campaigns[0].CampaignID,
                           'fc0ce7105baeaf97f47c99be31d02a91')
         self.assertEqual(campaigns[0].WebVersionURL,
-                          'http://createsend.com/t/r-765E86829575EE2C')
+                          'https://createsend.com/t/r-765E86829575EE2C')
         self.assertEqual(campaigns[0].WebVersionTextURL,
-                          'http://createsend.com/t/r-765E86829575EE2C/t')
+                          'https://createsend.com/t/r-765E86829575EE2C/t')
         self.assertEqual(campaigns[0].Subject, 'Campaign One')
         self.assertEqual(campaigns[0].Name, 'Campaign One')
         self.assertEqual(campaigns[0].SentDate, '2010-10-12 12:58:00')
@@ -69,9 +69,9 @@ class ClientTestCase:
         self.assertEqual(campaigns[0].Subject, "Magic Issue One")
         self.assertEqual(campaigns[0].DateCreated, "2011-05-24 10:37:00")
         self.assertEqual(campaigns[0].PreviewURL,
-                          "http://createsend.com/t/r-DD543521A87C9B8B")
+                          "https://createsend.com/t/r-DD543521A87C9B8B")
         self.assertEqual(campaigns[0].PreviewTextURL,
-                          "http://createsend.com/t/r-DD543521A87C9B8B/t")
+                          "https://createsend.com/t/r-DD543521A87C9B8B/t")
         self.assertEqual(campaigns[0].FromName, 'My Name')
         self.assertEqual(campaigns[0].FromEmail, 'myemail@example.com')
         self.assertEqual(campaigns[0].ReplyTo, 'myemail@example.com')
@@ -88,9 +88,9 @@ class ClientTestCase:
         self.assertEqual(drafts[0].Subject, 'Draft One')
         self.assertEqual(drafts[0].DateCreated, '2010-08-19 16:08:00')
         self.assertEqual(drafts[0].PreviewURL,
-                          'http://createsend.com/t/r-E97A7BB2E6983DA1')
+                          'https://createsend.com/t/r-E97A7BB2E6983DA1')
         self.assertEqual(drafts[0].PreviewTextURL,
-                          'http://createsend.com/t/r-E97A7BB2E6983DA1/t')
+                          'https://createsend.com/t/r-E97A7BB2E6983DA1/t')
         self.assertEqual(drafts[0].FromName, 'My Name')
         self.assertEqual(drafts[0].FromEmail, 'myemail@example.com')
         self.assertEqual(drafts[0].ReplyTo, 'myemail@example.com')

--- a/test/test_createsend.py
+++ b/test/test_createsend.py
@@ -190,36 +190,36 @@ class CreateSendTestCase:
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
             'templates/uhiuhiuhiuhiuhiuhiuh.json', 'custom_api_error.json', status=400)
-        self.assertRaises(self.error_responses[400], template.update, "Template One Updated", "http://templates.org/index.html",
-                          "http://templates.org/files.zip")
+        self.assertRaises(self.error_responses[400], template.update, "Template One Updated", "https://templates.org/index.html",
+                          "https://templates.org/files.zip")
 
     def test_unauthorized_on_put(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
             'templates/uhiuhiuhiuhiuhiuhiuh.json', 'custom_api_error.json', status=401)
-        self.assertRaises(self.error_responses[401], template.update, "Template One Updated", "http://templates.org/index.html",
-                          "http://templates.org/files.zip")
+        self.assertRaises(self.error_responses[401], template.update, "Template One Updated", "https://templates.org/index.html",
+                          "https://templates.org/files.zip")
 
     def test_not_found_on_put(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
             'templates/uhiuhiuhiuhiuhiuhiuh.json', None, status=404)
-        self.assertRaises(self.error_responses[404], template.update, "Template One Updated", "http://templates.org/index.html",
-                          "http://templates.org/files.zip")
+        self.assertRaises(self.error_responses[404], template.update, "Template One Updated", "https://templates.org/index.html",
+                          "https://templates.org/files.zip")
 
     def test_other_client_error_on_put(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
             'templates/uhiuhiuhiuhiuhiuhiuh.json', 'sample_client_error.json', status=418)
-        self.assertRaises(self.error_responses[418], template.update, "Template One Updated", "http://templates.org/index.html",
-                          "http://templates.org/files.zip")
+        self.assertRaises(self.error_responses[418], template.update, "Template One Updated", "https://templates.org/index.html",
+                          "https://templates.org/files.zip")
 
     def test_server_error_on_put(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")
         template.stub_request(
             'templates/uhiuhiuhiuhiuhiuhiuh.json', 'sample_server_error.json', status=500)
-        self.assertRaises(self.error_responses[500], template.update, "Template One Updated", "http://templates.org/index.html",
-                          "http://templates.org/files.zip")
+        self.assertRaises(self.error_responses[500], template.update, "Template One Updated", "https://templates.org/index.html",
+                          "https://templates.org/files.zip")
 
     def test_bad_request_on_delete(self):
         template = Template(self.cs.auth_details, "uhiuhiuhiuhiuhiuhiuh")

--- a/test/test_journey_email.py
+++ b/test/test_journey_email.py
@@ -47,7 +47,7 @@ class JourneyEmailTestCase:
         click_one = clicks.Results[0]
         self.assertEqual(click_one.EmailAddress, "asdf@example.com")
         self.assertEqual(click_one.Date, "2019-08-19 10:23:00")
-        self.assertEqual(click_one.URL, "http://mail.google.com/mail/?hl=en&tab=wm")
+        self.assertEqual(click_one.URL, "https://mail.google.com/mail/?hl=en&tab=wm")
         self.assertEqual(click_one.IPAddress, "198.148.196.144")
         self.assertEqual(click_one.Latitude, -33.8591)
         self.assertEqual(click_one.Longitude, 151.200195)

--- a/test/test_list.py
+++ b/test/test_list.py
@@ -150,7 +150,7 @@ class ListTestCase:
         self.assertEqual(len(res.Results[0].CustomFields), 5)
         self.assertEqual(res.Results[0].CustomFields[0].Key, "website")
         self.assertEqual(res.Results[0].CustomFields[
-                          0].Value, "http://example.com")
+                          0].Value, "https://example.com")
         self.assertEqual(res.Results[0].CustomFields[
                           1].Key, "multi select field")
         self.assertEqual(res.Results[0].CustomFields[1].Value, "option one")
@@ -181,7 +181,7 @@ class ListTestCase:
         self.assertEqual(len(res.Results[0].CustomFields), 5)
         self.assertEqual(res.Results[0].CustomFields[0].Key, "website")
         self.assertEqual(res.Results[0].CustomFields[
-                          0].Value, "http://example.com")
+                          0].Value, "https://example.com")
         self.assertEqual(res.Results[0].CustomFields[
                           1].Key, "multi select field")
         self.assertEqual(res.Results[0].CustomFields[1].Value, "option one")
@@ -283,7 +283,7 @@ class ListTestCase:
         self.assertEqual(hooks[0].WebhookID, "943678317049bc13")
         self.assertEqual(len(hooks[0].Events), 1)
         self.assertEqual(hooks[0].Events[0], "Deactivate")
-        self.assertEqual(hooks[0].Url, "http://www.postbin.org/d9w8ud9wud9w")
+        self.assertEqual(hooks[0].Url, "https://www.postbin.org/d9w8ud9wud9w")
         self.assertEqual(hooks[0].Status, "Active")
         self.assertEqual(hooks[0].PayloadFormat, "Json")
 
@@ -291,7 +291,7 @@ class ListTestCase:
         self.list.stub_request("lists/%s/webhooks.json" %
                                self.list.list_id, "create_list_webhook.json")
         webhook_id = self.list.create_webhook(
-            ["Unsubscribe", "Spam"], "http://example.com/unsub", "json")
+            ["Unsubscribe", "Spam"], "https://example.com/unsub", "json")
         self.assertEqual(webhook_id, "6a783d359bd44ef62c6ca0d3eda4412a")
 
     def test_test_webhook(self):

--- a/test/test_subscriber.py
+++ b/test/test_subscriber.py
@@ -20,7 +20,7 @@ class SubscriberTestCase:
         self.assertEqual(len(subscriber.CustomFields), 3)
         self.assertEqual(subscriber.CustomFields[0].Key, 'website')
         self.assertEqual(subscriber.CustomFields[
-                          0].Value, 'http://example.com')
+                          0].Value, 'https://example.com')
         self.assertEqual(subscriber.ReadsEmailWith, "Gmail")
 
     def test_get_without_arguments(self):
@@ -36,7 +36,7 @@ class SubscriberTestCase:
         self.assertEqual(len(subscriber.CustomFields), 3)
         self.assertEqual(subscriber.CustomFields[0].Key, 'website')
         self.assertEqual(subscriber.CustomFields[
-                          0].Value, 'http://example.com')
+                          0].Value, 'https://example.com')
         self.assertEqual(subscriber.ReadsEmailWith, "Gmail")
 
     def test_get_with_tracking_preference_included(self):
@@ -52,7 +52,7 @@ class SubscriberTestCase:
         self.assertEqual(len(subscriber.CustomFields), 3)
         self.assertEqual(subscriber.CustomFields[0].Key, 'website')
         self.assertEqual(subscriber.CustomFields[
-                          0].Value, 'http://example.com')
+                          0].Value, 'https://example.com')
         self.assertEqual(subscriber.ReadsEmailWith, "Gmail")
         self.assertEqual(subscriber.ConsentToTrack, "Yes")
 
@@ -66,7 +66,7 @@ class SubscriberTestCase:
     def test_add_with_custom_fields(self):
         self.subscriber.stub_request(
             "subscribers/%s.json" % self.list_id, "add_subscriber.json")
-        custom_fields = [{"Key": 'website', "Value": 'http://example.com/'}]
+        custom_fields = [{"Key": 'website', "Value": 'https://example.com/'}]
         email_address = self.subscriber.add(
             self.list_id, "subscriber@example.com", "Subscriber", custom_fields, True, "No")
         self.assertEqual(email_address, "subscriber@example.com")
@@ -85,7 +85,7 @@ class SubscriberTestCase:
         new_email = "new_email_address@example.com"
         self.subscriber.stub_request("subscribers/%s.json?email=%s" %
                                      (self.list_id, quote(self.subscriber.email_address)), None)
-        custom_fields = [{"Key": 'website', "Value": 'http://example.com/'}]
+        custom_fields = [{"Key": 'website', "Value": 'https://example.com/'}]
         self.subscriber.update(new_email, "Subscriber", custom_fields, True, "Yes")
         self.assertEqual(self.subscriber.email_address, new_email)
 
@@ -94,7 +94,7 @@ class SubscriberTestCase:
         self.subscriber.stub_request("subscribers/%s.json?email=%s" %
                                      (self.list_id, quote(self.subscriber.email_address)), None)
         custom_fields = [
-            {"Key": 'website', "Value": 'http://example.com/', "Clear": True}]
+            {"Key": 'website', "Value": 'https://example.com/', "Clear": True}]
         self.subscriber.update(new_email, "Subscriber", custom_fields, True, "No")
         self.assertEqual(self.subscriber.email_address, new_email)
 

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -9,8 +9,8 @@ class TemplateTestCase:
         client_id = '87y8d7qyw8d7yq8w7ydwqwd'
         t = Template()
         t.stub_request("templates/%s.json" % client_id, "create_template.json")
-        template_id = t.create(client_id, "Template One", "http://templates.org/index.html",
-                               "http://templates.org/files.zip")
+        template_id = t.create(client_id, "Template One", "https://templates.org/index.html",
+                               "https://templates.org/files.zip")
         self.assertEqual(template_id, "98y2e98y289dh89h9383891234")
         self.assertEqual(t.template_id, "98y2e98y289dh89h9383891234")
 
@@ -21,15 +21,15 @@ class TemplateTestCase:
         self.assertEqual(t.TemplateID, "98y2e98y289dh89h938389")
         self.assertEqual(t.Name, "Template One")
         self.assertEqual(
-            t.PreviewURL, "http://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753")
+            t.PreviewURL, "https://preview.createsend.com/createsend/templates/previewTemplate.aspx?ID=01AF532CD8889B33&d=r&c=E816F55BFAD1A753")
         self.assertEqual(
-            t.ScreenshotURL, "http://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600")
+            t.ScreenshotURL, "https://preview.createsend.com/ts/r/14/833/263/14833263.jpg?0318092600")
 
     def test_update(self):
         self.template.stub_request("templates/%s.json" %
                                    self.template.template_id, None)
         self.template.update(
-            "Template One Updated", "http://templates.org/index.html", "http://templates.org/files.zip")
+            "Template One Updated", "https://templates.org/index.html", "https://templates.org/files.zip")
 
     def test_delete(self):
         self.template.stub_request("templates/%s.json" %


### PR DESCRIPTION
My linter keeps flagging the http URLs so thought I'd try and fix it 🪓

- Updates various URLs to use HTTPS
- Fixes some URLs in CONTRIBUTING.md
- Use GH Workflow badge instead of inactive Travis one in documentation

This PR has no changes to user facing code.