### PR TITLE
COM-677: Remove redundant d&s markup option

### DIFF
--- a/lib/createsend/client.py
+++ b/lib/createsend/client.py
@@ -108,7 +108,7 @@ class Client(CreateSendBase):
         response = self._put(self.uri_for('setbasics'), json.dumps(body))
 
     def set_payg_billing(self, currency, can_purchase_credits, client_pays, markup_percentage,
-                         markup_on_delivery=0, markup_per_recipient=0, markup_on_design_spam_test=0):
+                         markup_on_delivery=0, markup_per_recipient=0):
         """Sets the PAYG billing settings for this client."""
         body = {
             "Currency": currency,
@@ -116,8 +116,7 @@ class Client(CreateSendBase):
             "ClientPays": client_pays,
             "MarkupPercentage": markup_percentage,
             "MarkupOnDelivery": markup_on_delivery,
-            "MarkupPerRecipient": markup_per_recipient,
-            "MarkupOnDesignSpamTest": markup_on_design_spam_test}
+            "MarkupPerRecipient": markup_per_recipient}
         response = self._put(self.uri_for('setpaygbilling'), json.dumps(body))
 
     def set_monthly_billing(self, currency, client_pays, markup_percentage, monthly_scheme=None):

--- a/test/fixtures/client_details.json
+++ b/test/fixtures/client_details.json
@@ -15,7 +15,6 @@
   "BillingDetails": {
      "CanPurchaseCredits": true,
      "Credits": 500,
-     "MarkupOnDesignSpamTest": 0.0,
      "ClientPays": true,
      "BaseRatePerRecipient": 1.0,
      "MarkupPerRecipient": 0.0,


### PR DESCRIPTION
As titled.
|test_client.py -> test_set_payg_billing|
|-----------------------|
|![image](https://github.com/user-attachments/assets/68732788-3a5c-4e75-a26d-b13a99130442)|
